### PR TITLE
feat(dev): modo de impersonacao de usuario em localhost

### DIFF
--- a/docs/DEV_IMPERSONATION.md
+++ b/docs/DEV_IMPERSONATION.md
@@ -1,0 +1,43 @@
+# Dev Impersonation — modo local
+
+Permite logar como qualquer usuário em **localhost** sem precisar de conta no Supabase ou popup do Google OAuth. Útil para Playwright e debug manual.
+
+## Como ligar
+
+1. Backend rodando com `NODE_ENV !== "production"` (qualquer valor que não seja `production`, ou variável ausente — o default do `npm run dev` já serve).
+2. Frontend rodando com `PUBLIC_ENVIRONMENT !== "production"` (default em `.env.example`).
+3. Acessar `http://localhost:5173/dev/impersonar`.
+
+A rota retorna 404 em produção (gate no `+page.ts`).
+
+## Uso
+
+- **Presets**: clique em "Estudante padrão", "Admin (escopo tickets)" ou "Superadmin" para preencher o form rapidamente.
+- **Custom**: edite `idUser`, `email`, `nomeCompleto`, `isAdmin`, `adminRole`, `adminScopes` (separados por vírgula). Defina pra onde redirecionar (`/upload-historico`, `/admin`, `/meu-fluxograma/Engenharia`, etc).
+- Click **Impersonar** → o `authStore` recebe o `UserModel` sintético, a flag `localStorage.nofluxo_dev_impersonate=true` é setada, e você é redirecionado.
+- **Limpar impersonação** desfaz tudo (`authStore.clear()` + remove flag).
+
+## Como funciona
+
+| Camada | Patch |
+|---|---|
+| `lib/stores/auth.ts` | `clear()` também remove `nofluxo_dev_impersonate`. |
+| `lib/guards/authGuard.ts:checkAuth` | Quando a flag está setada, pula `isSessionValid()` (que faria signOut imediato sem sessão Supabase real). |
+| `lib/services/auth.service.ts:getAuthHeaders` | Quando a flag está setada, envia `X-Dev-Impersonate: <email>` em vez de `Authorization: Bearer <token>`. |
+| `no_fluxo_backend/src/utils.ts:checkAuthorization` | Quando `NODE_ENV !== "production"` E header `X-Dev-Impersonate` presente, faz lookup em `public.users` por `id_user`, compara o email, e autoriza. |
+
+## Limitações & segurança
+
+- **Gate de produção**: tanto frontend (`+page.ts` 404 + `getAuthHeaders` só atua com flag) quanto backend (`NODE_ENV !== "production"`) bloqueiam o bypass em prod. Se quiser auditar, busque por `nofluxo_dev_impersonate` e `x-dev-impersonate` no código.
+- **UI-only vs full-stack**: se o `idUser`/`email` não existirem em `public.users`, as chamadas autenticadas falham no lookup (UI funciona, backend recusa). Para fluxo completo, use um user real do seed (a tabela `users` da sua instância Supabase de desenvolvimento).
+- **Não substitui testes E2E reais**: este modo serve pra exploratórios e debug. Cenários de produção (OAuth real, RLS strict) precisam de teste com usuário real.
+
+## Validação
+
+Spec Playwright em `no_fluxo_frontend_svelte/tests-e2e/dev-impersonation.spec.ts` — 5 cenários, todos PASS:
+
+1. Rota carrega e mostra título + presets
+2. Submeter form impersona, seta flag e redireciona
+3. Após impersonar, `authGuard` libera `/upload-historico` sem `signOut`
+4. Preset Admin preenche os campos corretamente
+5. Clear remove `user`, flag e exibe status

--- a/no_fluxo_backend/src/utils.ts
+++ b/no_fluxo_backend/src/utils.ts
@@ -20,6 +20,36 @@ export const Utils = {
 
     checkAuthorization: async (req: Request) => {
         const headers = req.headers;
+
+        // DEV-ONLY: bypass de autorização para impersonação local.
+        // Gated por NODE_ENV !== 'production'. Header X-Dev-Impersonate carrega o
+        // email do usuário a impersonar; o User-ID continua sendo lido normalmente.
+        // Útil para Playwright e debug manual sem precisar logar via Supabase.
+        if (process.env.NODE_ENV !== "production") {
+            const devImpersonate = headers["x-dev-impersonate"];
+            if (devImpersonate && typeof devImpersonate === "string") {
+                const userId = headers["user-id"];
+                if (!userId) {
+                    utilsLogger.error("[DEV-IMPERSONATE] User-ID header obrigatório mesmo com X-Dev-Impersonate");
+                    return false;
+                }
+                const { data: user, error: userError } = await SupabaseWrapper.get()
+                    .from("users")
+                    .select("*")
+                    .eq("id_user", userId);
+                if (userError || !user || user.length === 0) {
+                    utilsLogger.error(`[DEV-IMPERSONATE] usuário ${userId} não encontrado`);
+                    return false;
+                }
+                if (user[0].email !== devImpersonate) {
+                    utilsLogger.error(`[DEV-IMPERSONATE] email ${devImpersonate} não bate com idUser ${userId}`);
+                    return false;
+                }
+                utilsLogger.info(`[DEV-IMPERSONATE] autorizando ${devImpersonate} (idUser=${userId})`);
+                return true;
+            }
+        }
+
         const authorization = headers["authorization"];
         utilsLogger.info(`Authorization header: ${authorization}`);
         if (!authorization) {

--- a/no_fluxo_frontend_svelte/playwright.config.ts
+++ b/no_fluxo_frontend_svelte/playwright.config.ts
@@ -1,0 +1,24 @@
+import { defineConfig, devices } from '@playwright/test';
+
+export default defineConfig({
+	testDir: './tests-e2e',
+	timeout: 30_000,
+	expect: { timeout: 5_000 },
+	fullyParallel: false,
+	retries: 0,
+	workers: 1,
+	reporter: [['list'], ['html', { outputFolder: 'playwright-report', open: 'never' }]],
+	use: {
+		baseURL: 'http://localhost:5173',
+		trace: 'retain-on-failure',
+		screenshot: 'only-on-failure',
+		viewport: { width: 1280, height: 800 }
+	},
+	projects: [{ name: 'chromium', use: { ...devices['Desktop Chrome'] } }],
+	webServer: {
+		command: 'npm run dev',
+		port: 5173,
+		reuseExistingServer: true,
+		timeout: 60_000
+	}
+});

--- a/no_fluxo_frontend_svelte/src/lib/guards/authGuard.ts
+++ b/no_fluxo_frontend_svelte/src/lib/guards/authGuard.ts
@@ -47,12 +47,20 @@ export async function checkAuth(path: string): Promise<boolean> {
 
 	// Check if authenticated
 	if (state.isAuthenticated && state.user) {
-		// Verify session is still valid (covers expiry check previously in hooks.server.ts)
-		const isValid = await authService.isSessionValid();
-		if (!isValid) {
-			await authService.signOut();
-			await goto('/login?error=session_expired');
-			return false;
+		// DEV-ONLY: usuários impersonados localmente não têm sessão Supabase real,
+		// então pulamos a checagem de validade (que faria signOut imediato).
+		const isDevImpersonate =
+			typeof localStorage !== 'undefined' &&
+			localStorage.getItem('nofluxo_dev_impersonate') === 'true';
+
+		if (!isDevImpersonate) {
+			// Verify session is still valid (covers expiry check previously in hooks.server.ts)
+			const isValid = await authService.isSessionValid();
+			if (!isValid) {
+				await authService.signOut();
+				await goto('/login?error=session_expired');
+				return false;
+			}
 		}
 
 		// Rotas admin: exige o escopo correspondente (superadmin passa sempre)

--- a/no_fluxo_frontend_svelte/src/lib/services/auth.service.ts
+++ b/no_fluxo_frontend_svelte/src/lib/services/auth.service.ts
@@ -417,6 +417,18 @@ export class AuthService {
 	 * Get headers for authorized API requests
 	 */
 	async getAuthHeaders(): Promise<Record<string, string>> {
+		// DEV-ONLY: se a flag de impersonação dev estiver setada, pula refreshSession
+		// (que falharia sem sessão Supabase real) e manda o header X-Dev-Impersonate
+		// pro backend bypassar a verificação JWT.
+		if (typeof localStorage !== 'undefined' && localStorage.getItem('nofluxo_dev_impersonate') === 'true') {
+			const user = authStore.getUser();
+			return {
+				'X-Dev-Impersonate': user?.email || '',
+				'User-ID': user?.idUser?.toString() || '',
+				'Content-Type': 'application/json'
+			};
+		}
+
 		const session = await this.refreshSession();
 		const user = authStore.getUser();
 

--- a/no_fluxo_frontend_svelte/src/lib/stores/auth.ts
+++ b/no_fluxo_frontend_svelte/src/lib/stores/auth.ts
@@ -5,6 +5,8 @@ import { normalizeDadosFluxogramaFromStored } from '$lib/factories';
 
 const STORAGE_KEY = 'nofluxo_user';
 const ANON_KEY = 'nofluxo_anonimo';
+/** DEV-ONLY: marca que o usuário atual foi impersonado via /dev/impersonar. */
+const DEV_IMPERSONATE_KEY = 'nofluxo_dev_impersonate';
 
 // Initialize state from localStorage if available
 function getInitialState(): AuthState {
@@ -155,6 +157,7 @@ function createAuthStore() {
 			if (browser) {
 				localStorage.removeItem(STORAGE_KEY);
 				localStorage.removeItem(ANON_KEY);
+				localStorage.removeItem(DEV_IMPERSONATE_KEY);
 				// Remove anonymous cookie
 				document.cookie = 'nofluxo_anonimo=; path=/; max-age=0';
 			}

--- a/no_fluxo_frontend_svelte/src/routes/dev/impersonar/+page.svelte
+++ b/no_fluxo_frontend_svelte/src/routes/dev/impersonar/+page.svelte
@@ -1,0 +1,279 @@
+<script lang="ts">
+	import { goto } from '$app/navigation';
+	import { authStore } from '$lib/stores/auth';
+	import { config } from '$lib/config';
+	import type { UserModel } from '$lib/types/auth';
+
+	const DEV_IMPERSONATE_KEY = 'nofluxo_dev_impersonate';
+
+	type Preset = {
+		label: string;
+		description: string;
+		user: UserModel;
+	};
+
+	const presets: Preset[] = [
+		{
+			label: 'Estudante padrão',
+			description: 'idUser=1, sem admin, sem fluxograma carregado',
+			user: {
+				idUser: 1,
+				email: 'estudante@dev.local',
+				nomeCompleto: 'Estudante de Teste',
+				token: null,
+				isAdmin: false,
+				dadosFluxograma: null
+			}
+		},
+		{
+			label: 'Admin (escopo tickets)',
+			description: 'idUser=2, isAdmin=true, scopes=["tickets"]',
+			user: {
+				idUser: 2,
+				email: 'admin@dev.local',
+				nomeCompleto: 'Admin de Teste',
+				token: null,
+				isAdmin: true,
+				adminRole: 'admin',
+				adminScopes: ['tickets'],
+				dadosFluxograma: null
+			}
+		},
+		{
+			label: 'Superadmin',
+			description: 'idUser=3, todos os escopos liberados',
+			user: {
+				idUser: 3,
+				email: 'super@dev.local',
+				nomeCompleto: 'Superadmin de Teste',
+				token: null,
+				isAdmin: true,
+				adminRole: 'superadmin',
+				adminScopes: ['tickets', 'dashboard'],
+				dadosFluxograma: null
+			}
+		}
+	];
+
+	let idUser = $state(1);
+	let email = $state('estudante@dev.local');
+	let nomeCompleto = $state('Estudante de Teste');
+	let isAdmin = $state(false);
+	let adminRole = $state<'admin' | 'superadmin' | ''>('');
+	let adminScopes = $state('');
+	let redirectTo = $state('/upload-historico');
+	let status = $state<string | null>(null);
+
+	function applyPreset(preset: Preset) {
+		idUser = preset.user.idUser;
+		email = preset.user.email;
+		nomeCompleto = preset.user.nomeCompleto;
+		isAdmin = preset.user.isAdmin ?? false;
+		adminRole = preset.user.adminRole ?? '';
+		adminScopes = (preset.user.adminScopes ?? []).join(',');
+	}
+
+	function impersonate() {
+		const user: UserModel = {
+			idUser,
+			email,
+			nomeCompleto,
+			token: null,
+			isAdmin,
+			adminRole: adminRole || null,
+			adminScopes: adminScopes
+				? adminScopes.split(',').map((s) => s.trim()).filter(Boolean)
+				: [],
+			dadosFluxograma: null
+		};
+		localStorage.setItem(DEV_IMPERSONATE_KEY, 'true');
+		authStore.setUser(user);
+		status = `Impersonando ${email}. Redirecionando para ${redirectTo}...`;
+		setTimeout(() => goto(redirectTo), 300);
+	}
+
+	function clearImpersonation() {
+		localStorage.removeItem(DEV_IMPERSONATE_KEY);
+		authStore.clear();
+		status = 'Impersonação removida. authStore limpo.';
+	}
+</script>
+
+<svelte:head>
+	<title>Dev · Impersonar usuário</title>
+</svelte:head>
+
+<main class="wrap">
+	<header>
+		<h1>Dev · Impersonar usuário</h1>
+		<p class="warn">
+			Modo de desenvolvimento — <strong>não funciona em produção</strong>. PUBLIC_ENVIRONMENT atual:
+			<code>{config.isProd ? 'production' : 'development/other'}</code>.
+		</p>
+	</header>
+
+	<section class="presets">
+		<h2>Presets</h2>
+		<div class="preset-grid">
+			{#each presets as preset}
+				<button type="button" class="preset" onclick={() => applyPreset(preset)}>
+					<strong>{preset.label}</strong>
+					<span>{preset.description}</span>
+				</button>
+			{/each}
+		</div>
+	</section>
+
+	<section class="form">
+		<h2>Usuário customizado</h2>
+		<label>
+			idUser
+			<input type="number" bind:value={idUser} min="1" data-testid="idUser" />
+		</label>
+		<label>
+			Email (deve existir em <code>public.users</code> se você for chamar endpoints autenticados)
+			<input type="email" bind:value={email} data-testid="email" />
+		</label>
+		<label>
+			Nome completo
+			<input type="text" bind:value={nomeCompleto} data-testid="nomeCompleto" />
+		</label>
+		<label class="row">
+			<input type="checkbox" bind:checked={isAdmin} data-testid="isAdmin" />
+			isAdmin
+		</label>
+		{#if isAdmin}
+			<label>
+				adminRole
+				<select bind:value={adminRole} data-testid="adminRole">
+					<option value="">(nenhum)</option>
+					<option value="admin">admin</option>
+					<option value="superadmin">superadmin</option>
+				</select>
+			</label>
+			<label>
+				adminScopes (separados por vírgula, ex.: <code>tickets,dashboard</code>)
+				<input type="text" bind:value={adminScopes} data-testid="adminScopes" />
+			</label>
+		{/if}
+		<label>
+			Redirecionar para
+			<input type="text" bind:value={redirectTo} data-testid="redirectTo" />
+		</label>
+
+		<div class="actions">
+			<button type="button" class="primary" onclick={impersonate} data-testid="submit">
+				Impersonar
+			</button>
+			<button type="button" onclick={clearImpersonation} data-testid="clear">
+				Limpar impersonação
+			</button>
+		</div>
+
+		{#if status}
+			<p class="status" data-testid="status">{status}</p>
+		{/if}
+	</section>
+
+	<section class="docs">
+		<h2>Como funciona</h2>
+		<ul>
+			<li>Esta rota injeta um <code>UserModel</code> sintético direto no <code>authStore</code> e marca
+				<code>localStorage.nofluxo_dev_impersonate = "true"</code>.</li>
+			<li>O <code>authGuard</code> reconhece a flag e pula <code>isSessionValid()</code> (que falharia sem sessão Supabase real).</li>
+			<li>O <code>auth.service.getAuthHeaders()</code> manda <code>X-Dev-Impersonate: &lt;email&gt;</code> em vez de Bearer token.</li>
+			<li>O backend (<code>Utils.checkAuthorization</code>) honra esse header só quando <code>NODE_ENV !== "production"</code>, fazendo lookup do usuário em <code>public.users</code> por <code>id_user</code> e comparando o email.</li>
+			<li>Para impersonar um usuário real do banco, use o <code>idUser</code> e <code>email</code> que existem em <code>public.users</code>. Para teste puro de UI, qualquer valor funciona (chamadas autenticadas só falham no backend lookup).</li>
+		</ul>
+	</section>
+</main>
+
+<style>
+	.wrap {
+		max-width: 720px;
+		margin: 2rem auto;
+		padding: 0 1.5rem;
+		font-family: system-ui, -apple-system, sans-serif;
+		color: #222;
+	}
+	h1 { font-size: 1.6rem; margin-bottom: 0.25rem; }
+	h2 { font-size: 1.1rem; margin-top: 2rem; margin-bottom: 0.75rem; }
+	.warn {
+		background: #fff7ed;
+		border-left: 4px solid #f59e0b;
+		padding: 0.5rem 0.75rem;
+		font-size: 0.9rem;
+		border-radius: 4px;
+	}
+	.preset-grid {
+		display: grid;
+		grid-template-columns: 1fr;
+		gap: 0.5rem;
+	}
+	@media (min-width: 640px) {
+		.preset-grid { grid-template-columns: 1fr 1fr 1fr; }
+	}
+	.preset {
+		text-align: left;
+		padding: 0.75rem;
+		border: 1px solid #ddd;
+		border-radius: 6px;
+		background: #fafafa;
+		cursor: pointer;
+	}
+	.preset:hover { border-color: #6b46c1; background: #f3eefb; }
+	.preset strong { display: block; margin-bottom: 0.25rem; }
+	.preset span { font-size: 0.8rem; color: #555; }
+	label {
+		display: block;
+		margin: 0.5rem 0;
+		font-size: 0.9rem;
+	}
+	label.row {
+		display: flex;
+		align-items: center;
+		gap: 0.5rem;
+	}
+	input[type=text], input[type=email], input[type=number], select {
+		display: block;
+		width: 100%;
+		padding: 0.4rem 0.5rem;
+		font-size: 0.95rem;
+		border: 1px solid #ccc;
+		border-radius: 4px;
+		margin-top: 0.2rem;
+	}
+	.actions { margin-top: 1rem; display: flex; gap: 0.75rem; }
+	button.primary {
+		background: #6b46c1;
+		color: white;
+		border: none;
+		padding: 0.6rem 1.2rem;
+		font-weight: 600;
+		border-radius: 4px;
+		cursor: pointer;
+	}
+	button.primary:hover { background: #553099; }
+	button:not(.primary):not(.preset) {
+		background: white;
+		border: 1px solid #ccc;
+		padding: 0.6rem 1.2rem;
+		border-radius: 4px;
+		cursor: pointer;
+	}
+	.status {
+		margin-top: 1rem;
+		padding: 0.5rem 0.75rem;
+		background: #ecfdf5;
+		border-left: 4px solid #10b981;
+		border-radius: 4px;
+		font-size: 0.9rem;
+	}
+	.docs ul { font-size: 0.9rem; line-height: 1.5; padding-left: 1.25rem; }
+	code {
+		background: #f4f4f5;
+		padding: 0.1rem 0.3rem;
+		border-radius: 3px;
+		font-size: 0.85em;
+	}
+</style>

--- a/no_fluxo_frontend_svelte/src/routes/dev/impersonar/+page.ts
+++ b/no_fluxo_frontend_svelte/src/routes/dev/impersonar/+page.ts
@@ -1,0 +1,11 @@
+import { error } from '@sveltejs/kit';
+import { config } from '$lib/config';
+
+export const ssr = false;
+
+export function load() {
+	if (config.isProd) {
+		throw error(404, 'Not Found');
+	}
+	return {};
+}

--- a/no_fluxo_frontend_svelte/tests-e2e/dev-impersonation.spec.ts
+++ b/no_fluxo_frontend_svelte/tests-e2e/dev-impersonation.spec.ts
@@ -1,0 +1,83 @@
+import { test, expect } from '@playwright/test';
+
+/**
+ * Sessão Exploratória — /dev/impersonar
+ * Valida o modo dev de impersonação local (gated por PUBLIC_ENVIRONMENT !== 'production'):
+ * - Rota acessível em dev.
+ * - Submeter o form injeta um UserModel sintético no authStore + flag dev_impersonate.
+ * - Após impersonar, o authGuard libera rotas privadas sem chamar isSessionValid.
+ * - Clear remove o usuário e a flag.
+ */
+
+test.describe.serial('Dev Impersonation — sessão exploratória', () => {
+	test('Rota /dev/impersonar carrega e mostra o título + presets', async ({ page }) => {
+		await page.goto('/dev/impersonar', { waitUntil: 'networkidle' });
+		await expect(page.locator('h1')).toContainText('Impersonar usuário');
+		await expect(page.getByRole('button', { name: /Estudante padrão/ })).toBeVisible();
+		await expect(page.getByRole('button', { name: /Superadmin/ })).toBeVisible();
+	});
+
+	test('Submeter form impersona, seta flag e redireciona', async ({ page }) => {
+		await page.goto('/dev/impersonar');
+		await page.getByTestId('idUser').fill('42');
+		await page.getByTestId('email').fill('teste42@dev.local');
+		await page.getByTestId('nomeCompleto').fill('Usuário 42');
+		await page.getByTestId('redirectTo').fill('/upload-historico');
+		await page.getByTestId('submit').click();
+		await page.waitForURL(/upload-historico/, { timeout: 5_000 });
+
+		const localStorage = await page.evaluate(() => ({
+			user: window.localStorage.getItem('nofluxo_user'),
+			devImpersonate: window.localStorage.getItem('nofluxo_dev_impersonate')
+		}));
+		expect(localStorage.devImpersonate).toBe('true');
+		expect(localStorage.user).toBeTruthy();
+		const userObj = JSON.parse(localStorage.user!);
+		expect(userObj.idUser).toBe(42);
+		expect(userObj.email).toBe('teste42@dev.local');
+		expect(userObj.nomeCompleto).toBe('Usuário 42');
+	});
+
+	test('Após impersonar, authGuard libera /upload-historico (sem signOut)', async ({ page }) => {
+		await page.goto('/dev/impersonar');
+		await page.getByTestId('idUser').fill('99');
+		await page.getByTestId('email').fill('guarded@dev.local');
+		await page.getByTestId('nomeCompleto').fill('Guard Test');
+		await page.getByTestId('submit').click();
+		await page.waitForURL(/upload-historico/, { timeout: 5_000 });
+
+		// Confirma que NÃO redirecionou pra /login?error=session_expired
+		expect(page.url()).not.toContain('error=session_expired');
+		expect(page.url()).toContain('/upload-historico');
+	});
+
+	test('Preset Admin preenche campos corretamente', async ({ page }) => {
+		await page.goto('/dev/impersonar');
+		await page.getByRole('button', { name: /Admin \(escopo tickets\)/ }).click();
+		await expect(page.getByTestId('idUser')).toHaveValue('2');
+		await expect(page.getByTestId('email')).toHaveValue('admin@dev.local');
+		await expect(page.getByTestId('isAdmin')).toBeChecked();
+		await expect(page.getByTestId('adminRole')).toHaveValue('admin');
+		await expect(page.getByTestId('adminScopes')).toHaveValue('tickets');
+	});
+
+	test('Clear remove user, flag e mostra status', async ({ page }) => {
+		await page.goto('/dev/impersonar');
+		await page.getByTestId('idUser').fill('1');
+		await page.getByTestId('email').fill('a@b.c');
+		await page.getByTestId('nomeCompleto').fill('X');
+		// Não submete pra evitar redirect; só seta flag manualmente
+		await page.evaluate(() => {
+			localStorage.setItem('nofluxo_dev_impersonate', 'true');
+			localStorage.setItem('nofluxo_user', JSON.stringify({ idUser: 1, email: 'a@b.c', nomeCompleto: 'X' }));
+		});
+		await page.getByTestId('clear').click();
+		await expect(page.getByTestId('status')).toContainText('removida');
+		const ls = await page.evaluate(() => ({
+			user: window.localStorage.getItem('nofluxo_user'),
+			devImpersonate: window.localStorage.getItem('nofluxo_dev_impersonate')
+		}));
+		expect(ls.devImpersonate).toBeNull();
+		expect(ls.user).toBeNull();
+	});
+});


### PR DESCRIPTION
## Resumo
Rota `/dev/impersonar` (somente quando `PUBLIC_ENVIRONMENT != "production"`) permite injetar um `UserModel` sintético no `authStore`. Resolve a barreira de cobrir fluxos autenticados em Playwright sem conta Supabase real ou OAuth Google.

## O que entrega
- `no_fluxo_frontend_svelte/src/routes/dev/impersonar/{+page.svelte, +page.ts}` — form com 3 presets (Estudante, Admin, Superadmin) + custom; gate via `+page.ts` retorna 404 em produção
- `no_fluxo_frontend_svelte/src/lib/services/auth.service.ts` — `getAuthHeaders` envia `X-Dev-Impersonate` em vez de Bearer quando flag dev ativa
- `no_fluxo_frontend_svelte/src/lib/guards/authGuard.ts` — pula `isSessionValid` quando flag ativa
- `no_fluxo_frontend_svelte/src/lib/stores/auth.ts` — `clear()` também limpa a flag
- `no_fluxo_backend/src/utils.ts` — `checkAuthorization` aceita `X-Dev-Impersonate` apenas quando `NODE_ENV != "production"` com lookup em `public.users` E comparação de email
- `no_fluxo_frontend_svelte/tests-e2e/dev-impersonation.spec.ts` — **5/5 PASS em 8.9s**
- `docs/DEV_IMPERSONATION.md` — doc explicando uso, mecanismo e limitações

## Conflito potencial
Esta branch e a `fix/bugs-exploratorio-modulo4` (PR #7) tocam `authGuard.ts` e `stores/auth.ts` em regiões próximas. Merge desta primeiro deixa o fix preparado para rebase simples.

## Test plan
- [ ] `cd no_fluxo_frontend_svelte && npx playwright test tests-e2e/dev-impersonation.spec.ts`
- [ ] Conferir 404 em produção via `PUBLIC_ENVIRONMENT=production npm run build && npm run preview`

## Depende de
PR #1.