### PR TITLE
fix: corrige 8 defeitos descobertos no exploratorio do Modulo 4

### DIFF
--- a/no_fluxo_backend/parse-pdf/pdf_parser_final.py
+++ b/no_fluxo_backend/parse-pdf/pdf_parser_final.py
@@ -23,7 +23,21 @@ logging.basicConfig(
 logger = logging.getLogger(__name__)
 
 app = Flask(__name__)
+# D4: limite explícito de upload para não consumir RAM inteira em PDF gigante.
+# 10MB cobre histórico SIGAA completo (~500 disciplinas) com folga.
+app.config["MAX_CONTENT_LENGTH"] = 10 * 1024 * 1024
 CORS(app)
+
+
+@app.errorhandler(413)
+def too_large(_e):
+    return (
+        jsonify({
+            "error": "Arquivo muito grande. O limite é 10MB.",
+            "limit_mb": 10,
+        }),
+        413,
+    )
 
 
 # Request logging middleware
@@ -83,7 +97,10 @@ padrao_situacao = re.compile(
 )
 
 # Captura menção
-padrao_mencao = re.compile(r"^(SS|MS|MM|MI|II|SR|\-)$", re.MULTILINE)
+# D1: aceita hífen ASCII (-), en-dash (–, U+2013) e em-dash (—, U+2014).
+# PDFs do SIGAA gerados com auto-correção de hífens trocam o ASCII por unicode,
+# o que antes fazia o parser perder a disciplina inteira silenciosamente.
+padrao_mencao = re.compile(r"^(SS|MS|MM|MI|II|SR|[\-–—])$", re.MULTILINE)
 
 # Captura turma (letras e números)
 padrao_turma = re.compile(r"^([A-Z0-9]{1,3})$", re.MULTILINE)
@@ -971,7 +988,9 @@ def upload_pdf():
             return (
                 jsonify(
                     {
-                        "error": "Nenhuma informação textual pôde ser extraída do PDF via PyMuPDF. O PDF pode ser uma imagem de baixa qualidade, estar vazio ou corrompido."
+                        "error": "Nenhuma informação textual pôde ser extraída do PDF via PyMuPDF. O PDF pode ser uma imagem de baixa qualidade, estar vazio ou corrompido. Se for um PDF escaneado, use a variante OCR (pdf_parser_ocr.py) que executa Tesseract sobre as páginas.",
+                        "hint": "ocr_fallback_available",
+                        "ocr_endpoint": "pdf_parser_ocr.py"
                     }
                 ),
                 422,
@@ -1008,31 +1027,40 @@ def upload_pdf():
         )
         return jsonify(response_data)
 
-    except Exception as pdf_error:
-        # Handle PyMuPDF specific errors
-        if "fitz" in str(type(pdf_error)) or "mupdf" in str(pdf_error).lower():
-            error_msg = f"PDF read error: {str(pdf_error)}"
-            logger.error(error_msg)
-            return (
-                jsonify(
-                    {
-                        "error": f"Erro ao ler o PDF. Certifique-se de que é um PDF válido e não está corrompido: {str(pdf_error)}"
-                    }
-                ),
-                400,
-            )
     except Exception as e:
-        error_msg = f"Unexpected error: {str(e)}"
-        logger.error(error_msg)
+        # D13 (Crítico): handler único que SEMPRE retorna response — antes, o segundo
+        # `except Exception` era código morto e o primeiro só retornava no `if`,
+        # fazendo a view devolver None e o Werkzeug servir a página de debug com
+        # stack trace + paths absolutos. Agora separa erros conhecidos do PyMuPDF
+        # (400 — PDF inválido) dos demais (500 — mensagem genérica, stack só no log).
         import traceback
 
+        is_pdf_error = "fitz" in str(type(e)) or "mupdf" in str(e).lower()
+        if is_pdf_error:
+            logger.error(f"PDF read error: {e}")
+            return (
+                jsonify({
+                    "error": "Erro ao ler o PDF. Certifique-se de que o arquivo é um PDF válido e não está corrompido.",
+                    "detail": str(e),
+                }),
+                400,
+            )
+
+        logger.error(f"Unexpected error processing PDF: {e}")
         logger.error(traceback.format_exc())
         return (
-            jsonify({"error": f"Ocorreu um erro interno ao processar o PDF: {str(e)}"}),
+            jsonify({
+                "error": "Ocorreu um erro interno ao processar o PDF. A equipe foi notificada.",
+            }),
             500,
         )
 
 
 if __name__ == "__main__":
-    logger.info("Starting PDF parser service on port 3001")
-    app.run(debug=True, port=3001)
+    # D13: nunca rodar com debug=True por default — o reloader/console do Werkzeug
+    # expõe execução remota de código quando alguém alcança a porta. Para debug
+    # local, exporte FLASK_DEBUG=1 explicitamente.
+    import os as _os
+    debug_mode = _os.environ.get("FLASK_DEBUG", "0") == "1"
+    logger.info(f"Starting PDF parser service on port 3001 (debug={debug_mode})")
+    app.run(debug=debug_mode, port=3001)

--- a/no_fluxo_backend/src/controllers/assistente_controller.ts
+++ b/no_fluxo_backend/src/controllers/assistente_controller.ts
@@ -106,11 +106,14 @@ export const AssistenteController: EndpointController = {
         }),
 
         health: new Pair(RequestType.GET, async (_req: Request, res: Response) => {
+            // D-Sec-1: o /health era usado por monitoring externo, mas vazava quais
+            // provedores estavam configurados (ragflowConfigured / sabiaConfigured)
+            // para qualquer um sem autenticação. Resposta resumida agora:
+            // só 'healthy' | 'degraded' | 'down' — sem revelar a infra interna.
+            const anyUp = ragflow.isAvailable() || sabia.isAvailable();
             return res.json({
-                status: ragflow.isAvailable() || sabia.isAvailable() ? 'healthy' : 'degraded',
+                status: anyUp ? 'healthy' : 'degraded',
                 service: 'AI Assistant',
-                ragflowConfigured: ragflow.isAvailable(),
-                sabiaConfigured: sabia.isAvailable(),
                 timestamp: new Date().toISOString(),
             });
         }),

--- a/no_fluxo_frontend_svelte/src/lib/components/auth/LoginForm.svelte
+++ b/no_fluxo_frontend_svelte/src/lib/components/auth/LoginForm.svelte
@@ -2,6 +2,7 @@
 	import { onMount } from 'svelte';
 	import { authService } from '$lib/services/auth.service';
 	import { goto } from '$app/navigation';
+	import { page } from '$app/state';
 	import { ROUTES } from '$lib/config/routes';
 	import { isLoading, authError, authStore } from '$lib/stores/auth';
 	import { browser } from '$app/environment';
@@ -10,6 +11,34 @@
 	import { loginSchema } from '$lib/schemas/auth';
 
 	const REMEMBER_KEY = 'nofluxo_remember_email';
+
+	// D5 Vini (Médio): exibe a mensagem de sessão expirada quando o authGuard
+	// redirecionou com ?error=session_expired. Antes, o param chegava na URL e
+	// morria silenciosamente porque o LoginForm não lia $page.url.searchParams.
+	let queryError = $derived.by(() => {
+		const code = page.url?.searchParams?.get('error');
+		switch (code) {
+			case 'session_expired':
+				return 'Sua sessão expirou. Faça login novamente.';
+			case 'access_denied':
+				return 'Você não tem permissão para acessar essa página.';
+			default:
+				return '';
+		}
+	});
+
+	// D7 Vini (Médio): honra ?redirect= depois do login bem-sucedido em vez de
+	// mandar todo mundo cego para /upload-historico. Whitelist defensiva: aceita
+	// apenas paths internos (começando com '/' e sem '//' para evitar redirect
+	// para origem externa).
+	function getSafeRedirect(): string {
+		const candidate = page.url?.searchParams?.get('redirect') ?? '';
+		const decoded = candidate ? decodeURIComponent(candidate) : '';
+		if (decoded.startsWith('/') && !decoded.startsWith('//') && !decoded.includes('://')) {
+			return decoded;
+		}
+		return ROUTES.UPLOAD_HISTORICO;
+	}
 
 	let email = $state('');
 	let password = $state('');
@@ -82,7 +111,7 @@
 		const result = await authService.signIn(email, password);
 
 		if (result.success) {
-			await goto(ROUTES.UPLOAD_HISTORICO);
+			await goto(getSafeRedirect());
 		} else {
 			localError = result.error;
 		}
@@ -107,11 +136,11 @@
 	<!-- Title -->
 	
 
-	<!-- Error banner -->
-	{#if localError || $authError}
-		<div class="auth-error">
+	<!-- Error banner (inclui mensagem vinda do ?error= na URL — D5 Vini) -->
+	{#if localError || $authError || queryError}
+		<div class="auth-error" data-testid="login-error">
 			<AlertTriangle class="h-5 w-5 shrink-0 text-amber-600" />
-			<span>{localError || $authError}</span>
+			<span>{localError || $authError || queryError}</span>
 		</div>
 	{/if}
 

--- a/no_fluxo_frontend_svelte/src/lib/guards/authGuard.ts
+++ b/no_fluxo_frontend_svelte/src/lib/guards/authGuard.ts
@@ -42,11 +42,25 @@ export async function checkAuth(path: string): Promise<boolean> {
 	// Allow anonymous users
 	if (state.isAnonymous) return true;
 
-	// Still loading auth state — let the layout spinner handle it
-	if (state.isLoading) return true;
+	// D9/D10 (Alto, transversal): antes, qualquer rota privada acessada antes do
+	// bootstrap (state.isLoading=true) era liberada implicitamente, expondo a tela
+	// por alguns segundos enquanto a sessão era buscada. Agora aguardamos o boot
+	// terminar antes de decidir — bloquear é o default seguro.
+	if (state.isLoading) {
+		const start = Date.now();
+		while (Date.now() - start < 3000) {
+			const s = get(authStore);
+			if (!s.isLoading) break;
+			await new Promise((r) => setTimeout(r, 50));
+		}
+	}
 
-	// Check if authenticated
-	if (state.isAuthenticated && state.user) {
+	// Re-leitura do estado após o wait
+	const settled = get(authStore);
+	if (settled.isAnonymous) return true;
+
+	// Check if authenticated (lê o estado já estabilizado após o wait de isLoading — D9/D10)
+	if (settled.isAuthenticated && settled.user) {
 		// DEV-ONLY: usuários impersonados localmente não têm sessão Supabase real,
 		// então pulamos a checagem de validade (que faria signOut imediato).
 		const isDevImpersonate =
@@ -66,7 +80,7 @@ export async function checkAuth(path: string): Promise<boolean> {
 		// Rotas admin: exige o escopo correspondente (superadmin passa sempre)
 		if (requiresAdmin(path)) {
 			const scope = requiredAdminScope(path);
-			if (!scope || !hasAdminScope(state.user, scope)) {
+			if (!scope || !hasAdminScope(settled.user, scope)) {
 				await goto('/suporte?error=access_denied');
 				return false;
 			}

--- a/no_fluxo_frontend_svelte/src/lib/stores/auth.ts
+++ b/no_fluxo_frontend_svelte/src/lib/stores/auth.ts
@@ -17,6 +17,20 @@ function getInitialState(): AuthState {
 		if (storedUser && storedUser !== 'null') {
 			try {
 				const rawUser = JSON.parse(storedUser);
+				// D4 Vini (Médio): antes, qualquer JSON com `email` virava UserModel com
+				// idUser=0 e isAuthenticated=true — permitindo que um atacante injetasse
+				// um usuário fantasma só com addInitScript. Agora exigimos um idUser real
+				// (camelCase ou snake_case) E email válido antes de hidratar a sessão.
+				const idUserCandidate = rawUser.idUser ?? rawUser.id_user;
+				const emailCandidate = String(rawUser.email ?? '').trim();
+				const hasValidIdUser =
+					typeof idUserCandidate === 'number' && Number.isFinite(idUserCandidate) && idUserCandidate > 0;
+				const hasValidEmail = emailCandidate.length > 0 && emailCandidate.includes('@');
+				if (!hasValidIdUser || !hasValidEmail) {
+					localStorage.removeItem(STORAGE_KEY);
+					throw new Error('storedUser inválido: idUser/email ausentes ou malformados');
+				}
+
 				// Normalize fluxograma so codigoMateria/status/mencao are always in the expected shape
 				const dadosFluxograma = normalizeDadosFluxogramaFromStored(
 					rawUser.dadosFluxograma ?? rawUser.dados_fluxograma ?? null
@@ -26,8 +40,8 @@ function getInitialState(): AuthState {
 				const user: UserModel = rawUser.idUser !== undefined
 					? { ...rawUser, dadosFluxograma: dadosFluxograma ?? rawUser.dadosFluxograma ?? null, cargaHorariaIntegralizada: cargaHorariaIntegralizada ?? undefined }
 					: {
-							idUser: rawUser.id_user ?? 0,
-							email: rawUser.email ?? '',
+							idUser: idUserCandidate,
+							email: emailCandidate,
 							nomeCompleto: rawUser.nome_completo ?? '',
 							token: rawUser.token ?? null,
 							dadosFluxograma: dadosFluxograma ?? rawUser.dados_fluxograma ?? null,


### PR DESCRIPTION
## Resumo
Aplica os fixes mais urgentes/objetivos catalogados nos 4 relatórios exploratórios (Enzo, André, Vini, Kauan). Cada hunk cita o ID do defeito e a evidência.

## Defeitos corrigidos

### Backend Flask (`parse-pdf/pdf_parser_final.py`)
- **D13 Crítico**: bloco `except` duplicado virou um único handler que SEMPRE retorna response (antes a view devolvia `None` em qualquer erro que não citasse "fitz"/"mupdf", fazendo Werkzeug servir debugger com stack).
- **D13 Crítico**: `app.run` debug agora gateado por `FLASK_DEBUG=1` (default False).
- **D4 Alto**: `app.config["MAX_CONTENT_LENGTH"] = 10MB` + handler 413 amigável.
- **D5 Alto**: mensagem do 422 aponta para `pdf_parser_ocr.py` como fallback explícito.
- **D1 Alto**: `padrao_mencao` agora aceita en-dash (U+2013) e em-dash (U+2014).

### Backend Node (`assistente_controller.ts`)
- **D-Sec-1 Médio-Alto**: `/assistente/health` não expõe mais `ragflowConfigured`/`sabiaConfigured` anonimamente.

### Frontend (`lib/guards/authGuard.ts`, `lib/stores/auth.ts`, `LoginForm.svelte`)
- **D9/D10 Alto transversal**: `checkAuth` aguarda até 3s o bootstrap terminar antes de decidir.
- **D4 Médio (Vini)**: `getInitialState` agora exige `idUser` numérico > 0 E email com "@".
- **D5 Médio (Vini)**: `queryError` derivado de `$page.url.searchParams` exibe mensagem de sessão expirada.
- **D7 Médio (Vini)**: `getSafeRedirect` lê `?redirect=` com whitelist (paths internos).

## NÃO incluídos (precisam design decision — viram issue)
- **Enzo D5**: adicionar auth requirement em `POST /analyze-sabia` (mudança breaking — exige estratégia de quem pode usar a IA).
- **André D5**: debounce na busca (precisa decidir tempo + se aplica a todas as rotas).
- **Enzo D-UX-4**: botão cancelar no stream (precisa AbortController + lifecycle de cancel — refactor).

## Test plan
- [ ] Backend Node: `cd no_fluxo_backend && npm test`
- [ ] Backend Flask: `cd no_fluxo_backend/parse-pdf && pytest tests/test_exploratorio_kauan.py -v`
- [ ] Frontend: `cd no_fluxo_frontend_svelte && npx playwright test`

## Depende de
- PRs #1 a #5 (testes que descobriram os defeitos).
- **PR #6 (`feat/dev-impersonation`)** — esta branch toca `authGuard.ts` e `stores/auth.ts` em regiões próximas. **Rebase necessário após o merge do #6** (conflito trivial — manter os dois patches).