### PR TITLE
fix(mcp): busca semantica quebrada em prod por modelo de embedding aposentado

### DIFF
--- a/mcp_agent/api_producao.py
+++ b/mcp_agent/api_producao.py
@@ -321,7 +321,7 @@ def ferramenta_buscar_materias_unb(termos_busca: list) -> str:
 
         # 1. GERAÇÃO EM LOTE (BATCH EMBEDDING): 1 única chamada para a API do Gemini
         result = genai.embed_content(
-            model="models/text-embedding-004",
+            model="models/gemini-embedding-001",
             content=termos_validos,
             task_type="retrieval_query",
             output_dimensionality=256,
@@ -339,7 +339,7 @@ def ferramenta_buscar_materias_unb(termos_busca: list) -> str:
                 "match_materias",
                 {
                     "query_embedding": vetor,
-                    "match_threshold": 0.0,
+                    "match_threshold": 0.6,
                     "match_count": 20,  # Puxa as 5 melhores de cada termo
                 },
             ).execute()
@@ -383,9 +383,7 @@ def ferramenta_buscar_materias_unb(termos_busca: list) -> str:
 
     except Exception as e:
         print(f"❌ Erro na ferramenta de busca, tente novamente mais tarde: {e}")
-        with open("error_log.txt", "w") as f:
-            f.write(str(e))
-        return json.dumps([{"codigo": "ERRO", "nome": f"Exception: {str(e)}", "similaridade": 0}], ensure_ascii=False)
+        return json.dumps([])
 
 
 def ferramenta_explicar_materia(termo: str) -> dict:

--- a/mcp_agent/databaseScript_gemini.py
+++ b/mcp_agent/databaseScript_gemini.py
@@ -46,9 +46,9 @@ for materia in tqdm(all_materias, desc="Calculando Embeddings (Gemini)"):
     texto_busca = f"Disciplina: {nome}. Ementa: {ementa}"
     
     try:
-        # Usa o mesmo modelo que consertamos na API
+        # Usa o mesmo modelo da API (api_producao.py)
         result = genai.embed_content(
-            model="models/text-embedding-004",
+            model="models/gemini-embedding-001",
             content=texto_busca,
             task_type="retrieval_document",
             output_dimensionality=256


### PR DESCRIPTION
## Problema

O merge da branch antiga trouxe o commit `906c05a0`, que trocou o modelo de embedding do agente:

```diff
- model="models/gemini-embedding-001"
+ model="models/text-embedding-004"
```

O `text-embedding-004` **foi aposentado da API do Gemini**. Toda chamada de `embedContent` passou a retornar 404, derrubando **100% das buscas semânticas do Darcy em produção** — a `ferramenta_buscar_materias_unb` caía direto no `except`.

## Evidência

Chamada real contra a API, com a chave de produção:

```
=== Modelos que suportam embedContent ===
 - models/gemini-embedding-001
 - models/gemini-embedding-2-preview
 - models/gemini-embedding-2

models/text-embedding-004   → FALHOU: NotFound 404
models/gemini-embedding-001 → OK (2 vetores, dim 256)
```

O 404 bate exatamente com o que estava no `error_log.txt` gerado em produção.

## O que este PR reverte

O mesmo commit deixou passar duas sobras de debug, corrigidas aqui junto:

| Local | Estava | Voltou para | Efeito |
|---|---|---|---|
| `api_producao.py:324` | `text-embedding-004` | `gemini-embedding-001` | 404 em toda busca |
| `api_producao.py:342` | `match_threshold: 0.0` | `0.6` | sem corte, qualquer resultado irrelevante passava |
| `api_producao.py:386-388` | grava `error_log.txt` + retorna `{"codigo": "ERRO", "nome": "Exception: ..."}` | `return json.dumps([])` | **vazava a exceção para o usuário final**, travestida de matéria |

`databaseScript_gemini.py` usava o mesmo modelo morto e falharia ao repopular os embeddings — corrigido também.

Com isso, `api_producao.py` volta a ser byte-idêntico à versão pré-regressão (blob `8795a25e`).

## Verificação

Rodei a função real `ferramenta_buscar_materias_unb` contra o Supabase de produção:

```
[DEBUG] Resultados para 'inteligencia artificial': 20 encontrados.
[DEBUG] Resultados para 'compiladores': 20 encontrados.
   0.82  FGA0002  FUNDAMENTOS DE COMPILADORES
   0.81  CIC0204  COMPILADORES
   0.79  ICE0006  FORMACAO EM INTELIGENCIA ARTIFICIAL
```

## Banco não precisa ser repopulado

As similaridades em ~0.8 nos matches exatos confirmam que os vetores já gravados em `materias.embedding` foram gerados com `gemini-embedding-001` e seguem íntegros. O `databaseScript_gemini.py` nunca chegou a corromper nada: ele descarta a matéria quando o `embed_content` lança (`if vetor:`), então nenhum upsert ruim aconteceu.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
