### PR TITLE
fix(docker): imagem do mcp-agent crashava no boot sem tool_call_utils

### DIFF
--- a/k8s.mcp-agent.Dockerfile
+++ b/k8s.mcp-agent.Dockerfile
@@ -23,8 +23,11 @@ RUN useradd -r -u 1001 appuser
 # Copy installed packages from builder
 COPY --from=builder /install /usr/local
 
-# Copy only the production API source
-COPY --from=builder /app/src/api_producao.py ./
+# Copy the production API source. Precisa ser *.py, e nao apenas
+# api_producao.py: o modulo importa vizinhos (tool_call_utils) e copiar um
+# arquivo so faz o uvicorn morrer com ModuleNotFoundError na subida.
+# O .dockerignore ja mantem .env* e __pycache__ fora do build context.
+COPY --from=builder /app/src/*.py ./
 
 RUN chown -R appuser:appuser /app
 


### PR DESCRIPTION
## Sintoma

O agente está quebrado em produção e **nenhum deploy dos últimos dias teve efeito**, mesmo os que fecharam verdes.

`darcy-nofluxo.crianex.com/openapi.json` expõe hoje:

```
/health              ['get']
/recomendar          ['post']
/recomendar-stream   ['post']
```

Falta `/buscar-materias`, que está no `main` desde `b1b44e0e` (PR #139, mergeado hoje). Produção roda código **anterior** a esse commit.

## Causa raiz

O Dockerfile levava um único arquivo para a imagem final:

```dockerfile
COPY --from=builder /app/src/api_producao.py ./
```

Só que desde `e3b69e8c` o `api_producao.py` importa um vizinho:

```python
# mcp_agent/api_producao.py:12
from tool_call_utils import extrair_tool_call_texto, termo_materia
```

Reproduzi o layout exato da imagem (um diretório só com `api_producao.py`) e rodei o import do `CMD`:

```
File "/app/api_producao.py", line 12, in <module>
    from tool_call_utils import extrair_tool_call_texto, termo_materia
ModuleNotFoundError: No module named 'tool_call_utils'
```

O uvicorn não consegue importar `api_producao:app` → o container sai → o Kubernetes mantém o ReplicaSet antigo no ar. Daí a produção congelada.

## Por que os deploys ficaram verdes

A plataforma responde ao `start_build` com:

```json
{ "message": "Build skipped; will auto-deploy using existing image",
  "skipped": true, "status": "succeeded", "success": true }
```

Sem `jobName`, o `deploy_local.py:562-576` trata como sucesso imediato — o `--wait` não tem no que esperar. A imagem é empurrada para o registry, mas **ninguém valida que o pod subiu**. Os três apps (backend, frontend, mcp-agent) caem nesse mesmo caminho.

## Correção

```diff
-COPY --from=builder /app/src/api_producao.py ./
+COPY --from=builder /app/src/*.py ./
```

Copiar `*.py` resolve a classe inteira do problema: qualquer módulo novo passa a entrar na imagem sozinho, sem precisar lembrar de editar o Dockerfile. O `.dockerignore` já mantém `mcp_agent/.env*` e `__pycache__/` fora do build context, então nenhum segredo entra na imagem.

## Verificação

Mesmo layout, agora com `*.py`:

```
=== /app apos a correcao ===
api_producao.py  databaseScript.py  databaseScript_gemini.py
test_tool_call_utils.py  tool_call_utils.py

OK: app carregou
rotas: ['/buscar-materias', '/health', '/recomendar', '/recomendar-stream']
```

## Fica em aberto (fora do escopo deste PR)

1. **O deploy mente.** Enquanto a plataforma devolver `skipped: true` sem `jobName`, um pod em CrashLoopBackOff continua dando build verde. Vale um smoke check pós-deploy batendo no `health_path` (já existe em `deploy_config.py`) antes de o job encerrar.
2. **Erro de tool call no `/recomendar`.** Com a imagem velha, produção devolve HTTP 500: `Sorry, we couldn't find the answers to the following tool calls: call_...`. Precisa ser reavaliado depois que a versão nova estiver realmente no ar — pode já estar resolvido pelo `tool_call_utils`, que é justamente o módulo que nunca chegou lá.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
