### PR TITLE
fix(ci): adiciona retry no login do registry privado no Deploy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -39,11 +39,14 @@ jobs:
         uses: docker/setup-qemu-action@v3
 
       - name: Log in to private registry
-        uses: docker/login-action@v3
+        uses: nick-fields/retry@v3
         with:
-          registry: registry.kubernetes.crianex.com
-          username: ${{ secrets.REGISTRY_USERNAME }}
-          password: ${{ secrets.REGISTRY_PASSWORD }}
+          timeout_minutes: 2
+          max_attempts: 5
+          retry_wait_seconds: 10
+          command: |
+            echo "${{ secrets.REGISTRY_PASSWORD }}" | docker login registry.kubernetes.crianex.com \
+              --username "${{ secrets.REGISTRY_USERNAME }}" --password-stdin
 
       - name: Deploy
         env:


### PR DESCRIPTION
## Problema

O workflow `Deploy` vinha falhando de forma intermitente no step **"Log in to private registry"**:

\`\`\`
Error response from daemon: Get "https://registry.kubernetes.crianex.com/v2/":
net/http: request canceled while waiting for connection (Client.Timeout exceeded while awaiting headers)
\`\`\`

## Investigação

- Não é regressão de código: o job falha **antes** de qualquer build rodar.
- O mesmo erro aparece de forma esparsa em commits não relacionados ao longo de várias semanas (22/07, 03/08 ×2, 05/08), sempre no mesmo step.
- Testado diretamente: `https://registry.kubernetes.crianex.com/v2/` responde em <1s (401, esperado sem credenciais) — o registry está no ar.
- Conclusão: flakiness de rede intermitente entre os runners do GitHub Actions e o registry self-hosted, sem retry configurado.

## Correção

Troca `docker/login-action` por `docker login` envolto em `nick-fields/retry` (5 tentativas, 10s de espera entre tentativas, timeout de 2min por tentativa), para que uma falha transitória de rede não derrube o deploy inteiro.

Nota: os workflows `CI` e `Security and Code Quality` continuam vermelhos neste PR — isso é crônico desde 18/07 (débito técnico de cobertura de testes já mapeado), não relacionado a esta mudança.