### PR TITLE
fix(ci): auto-retry do Deploy em runner novo quando falhar

### DIFF
--- a/.github/workflows/deploy-auto-retry.yml
+++ b/.github/workflows/deploy-auto-retry.yml
@@ -1,0 +1,30 @@
+name: Deploy Auto-retry
+
+# O job "deploy" do workflow Deploy falha de forma intermitente ao logar no
+# registry privado (registry.kubernetes.crianex.com) por bloqueio/timeout de
+# rede específico do IP do runner do GitHub Actions — não é flaky por
+# requisição (retry dentro do mesmo job não ajuda, porque reusa o mesmo IP),
+# é flaky por runner. Um runner novo (IP novo) costuma funcionar.
+# Este workflow reexecuta só os jobs que falharam em uma execução nova,
+# limitado a algumas tentativas, para não mascarar uma falha real de código.
+on:
+  workflow_run:
+    workflows: ["Deploy"]
+    types: [completed]
+
+permissions:
+  actions: write
+
+jobs:
+  retry:
+    if: >
+      github.event.workflow_run.conclusion == 'failure' &&
+      github.event.workflow_run.run_attempt < 4
+    runs-on: ubuntu-latest
+    steps:
+      - name: Re-executa os jobs que falharam em um runner novo
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          echo "Deploy falhou (tentativa ${{ github.event.workflow_run.run_attempt }}), reexecutando em runner novo..."
+          gh run rerun ${{ github.event.workflow_run.id }} --failed --repo ${{ github.repository }}


### PR DESCRIPTION
## Contexto

Segue o PR #143. O retry adicionado lá (dentro do próprio job) **não resolveu** — a última execução do `Deploy` mostrou as 5 tentativas falhando de forma idêntica, todas com ~15s de timeout, no mesmo runner:

\`\`\`
Attempt 1: context deadline exceeded
Attempt 2: net/http: request canceled while waiting for connection (Client.Timeout exceeded)
Attempt 3: (idêntico)
Attempt 4: (idêntico)
Attempt 5: (idêntico)
\`\`\`

## Diagnóstico atualizado

Isso descarta "flakiness aleatória de pacote". Se fosse isso, ao menos 1 das 5 tentativas teria passado. O padrão real: dentro de uma mesma execução (mesmo runner = mesmo IP de saída), a conexão trava sempre. Já entre execuções diferentes (runners diferentes), historicamente sucesso e falha aparecem intercalados, às vezes a poucos minutos de distância (ex: 03/08 22:29 falhou, 23:00 funcionou, 23:12 falhou, 23:14 funcionou).

Isso é consistente com algum firewall/WAF na frente de `registry.kubernetes.crianex.com` bloqueando parte das faixas de IP usadas pelos runners hospedados do GitHub Actions (comportamento comum contra ranges de datacenter/cloud). Do meu IP residencial, o registry respondeu em <1s sem problema.

## O que este PR faz

Adiciona `deploy-auto-retry.yml`: escuta o término do workflow `Deploy` e, se ele falhou, reexecuta só os jobs que falharam (`gh run rerun --failed`) — isso sobe um **runner novo com IP novo**, dando outra chance de cair em um caminho de rede que não está bloqueado. Limitado a `run_attempt < 4` para não mascarar indefinidamente uma falha real de código (só re-tenta 3x, depois fica falho de verdade).

## O que este PR não faz

Não corrige a causa raiz, que é de infraestrutura fora deste repositório — provavelmente uma allowlist de IP desatualizada ou uma regra de WAF/rate-limit agressiva demais na frente do registry. Quem administra o cluster Kubernetes/registry (`kubernetes.crianex.com`) precisa checar os logs do firewall/ingress e liberar as faixas de IP do GitHub Actions (documentadas em https://api.github.com/meta, chave `actions`), ou investigar por que TLS handshakes vindos de IPs de datacenter estão travando em ~15s.