### PR TITLE
feat(home): vitrine da equipe com fundadores e mantenedores

### DIFF
--- a/no_fluxo_frontend_svelte/src/lib/components/home/MemberCard.svelte
+++ b/no_fluxo_frontend_svelte/src/lib/components/home/MemberCard.svelte
@@ -8,6 +8,11 @@
 		instagram?: string;
 		linkedin?: string;
 		email?: string;
+		role?: string;
+		funcao?: string;
+		variant?: 'founder' | 'maintainer' | 'default';
+		autoRotate?: boolean;
+		rotateDelay?: number;
 	}
 
 	let {
@@ -16,12 +21,32 @@
 		specialties = [],
 		instagram = '',
 		linkedin = '',
-		email = ''
+		email = '',
+		role = 'Desenvolvedor',
+		funcao = '',
+		variant = 'default',
+		autoRotate = false,
+		rotateDelay = 0
 	}: Props = $props();
 	let imageError = $state(false);
 	let currentSlide = $state(0);
+	let hovered = $state(false);
 
 	const totalSlides = 3;
+	const SLIDE_MS = 4200;
+
+	$effect(() => {
+		if (!autoRotate || hovered) return;
+		// lê currentSlide para reagendar a cada troca (automática ou manual)
+		const current = currentSlide;
+		const timer = setTimeout(
+			() => {
+				currentSlide = (current + 1) % totalSlides;
+			},
+			current === 0 && rotateDelay ? SLIDE_MS + rotateDelay : SLIDE_MS
+		);
+		return () => clearTimeout(timer);
+	});
 
 	const avatarUrl = $derived(`https://avatars.githubusercontent.com/${githubUsername}`);
 	const githubUrl = $derived(`https://github.com/${githubUsername}`);
@@ -48,7 +73,15 @@
 	}
 </script>
 
-<div class="team-card nf-card-surface nf-card-interactive">
+<div
+	class="team-card nf-card-surface nf-card-interactive"
+	class:is-founder={variant === 'founder'}
+	class:is-maintainer={variant === 'maintainer'}
+	onmouseenter={() => (hovered = true)}
+	onmouseleave={() => (hovered = false)}
+	role="group"
+	aria-label={`${name} — ${role}`}
+>
 	<div class="carousel-header">
 		<div class="carousel-controls">
 			<button class="carousel-btn" onclick={previousSlide} aria-label="Card anterior">
@@ -85,11 +118,17 @@
 			</div>
 
 			<h4 class="team-name">{name}</h4>
-			<span class="team-role">Desenvolvedor</span>
+			<span class="team-role">{role}</span>
+			{#if funcao}
+				<span class="team-funcao">{funcao}</span>
+			{/if}
 		</div>
 	{:else if currentSlide === 1}
 		<div class="member-slide">
-			<h4 class="slide-title">Especialidades</h4>
+			<h4 class="slide-title">O que faz</h4>
+			{#if funcao}
+				<p class="slide-subtitle">{funcao}</p>
+			{/if}
 			<ul class="specialties-list">
 				{#if specialties.length > 0}
 					{#each specialties as specialty}
@@ -144,11 +183,83 @@
 
 <style>
 	.team-card {
+		position: relative;
 		padding: 1rem;
 		display: flex;
 		flex-direction: column;
 		justify-content: space-between;
-		min-height: 280px;
+		min-height: 296px;
+		height: 100%;
+	}
+
+	/* anel de destaque sobreposto: não conflita com a borda do nf-card-surface */
+	.team-card.is-founder::after,
+	.team-card.is-maintainer::after {
+		content: '';
+		position: absolute;
+		inset: 0;
+		border-radius: inherit;
+		pointer-events: none;
+		border: 1.5px solid transparent;
+	}
+
+	.team-card.is-founder {
+		box-shadow:
+			0 0 0 1px rgba(233, 187, 92, 0.28),
+			0 10px 32px rgba(233, 187, 92, 0.12);
+	}
+
+	.team-card.is-founder::after {
+		border-color: rgba(240, 197, 106, 0.75);
+		background:
+			linear-gradient(
+					160deg,
+					rgba(255, 214, 128, 0.16) 0%,
+					rgba(255, 214, 128, 0) 45%,
+					rgba(255, 214, 128, 0.08) 100%
+				)
+				border-box;
+	}
+
+	.team-card.is-founder .team-avatar,
+	.team-card.is-founder .fallback-avatar {
+		box-shadow:
+			0 0 0 2px rgba(240, 197, 106, 0.8),
+			0 0 16px rgba(240, 197, 106, 0.3);
+	}
+
+	.team-card.is-founder .team-role {
+		color: #f0c56a;
+		font-weight: 600;
+	}
+
+	.team-card.is-maintainer {
+		box-shadow:
+			0 0 0 1px hsl(var(--primary) / 0.35),
+			0 10px 32px hsl(var(--primary) / 0.18);
+	}
+
+	.team-card.is-maintainer::after {
+		border-color: hsl(var(--primary) / 0.75);
+		background: linear-gradient(
+				160deg,
+				hsl(var(--primary) / 0.16) 0%,
+				hsl(var(--primary) / 0) 45%,
+				hsl(var(--primary) / 0.1) 100%
+			)
+			border-box;
+	}
+
+	.team-card.is-maintainer .team-avatar,
+	.team-card.is-maintainer .fallback-avatar {
+		box-shadow:
+			0 0 0 2px hsl(var(--primary) / 0.85),
+			0 0 16px hsl(var(--primary) / 0.35);
+	}
+
+	.team-card.is-maintainer .team-role {
+		color: hsl(var(--primary));
+		font-weight: 600;
 	}
 
 	.carousel-header {
@@ -182,6 +293,7 @@
 	}
 
 	.member-slide {
+		animation: slide-in 0.42s cubic-bezier(0.4, 0, 0.2, 1);
 		display: flex;
 		flex-direction: column;
 		align-items: center;
@@ -235,11 +347,32 @@
 		letter-spacing: 0.5px;
 	}
 
+	.team-funcao {
+		color: hsl(var(--muted-foreground));
+		font-size: clamp(0.6875rem, 1.2vw, 0.8125rem);
+		line-height: 1.3;
+		max-width: 90%;
+		/* altura fixa de 2 linhas mantém todos os cards alinhados */
+		min-height: 2.6em;
+		display: -webkit-box;
+		-webkit-line-clamp: 2;
+		line-clamp: 2;
+		-webkit-box-orient: vertical;
+		overflow: hidden;
+	}
+
 	.slide-title {
 		color: hsl(var(--foreground));
 		font-size: 1rem;
 		font-weight: 700;
 		margin-bottom: 0.25rem;
+	}
+
+	.slide-subtitle {
+		color: hsl(var(--muted-foreground));
+		font-size: 0.8125rem;
+		line-height: 1.35;
+		margin: -0.15rem 0 0.35rem;
 	}
 
 	.specialties-list {
@@ -314,5 +447,22 @@
 
 	.dot.active {
 		background: #f9fafb;
+	}
+
+	@keyframes slide-in {
+		from {
+			opacity: 0;
+			transform: translateY(8px);
+		}
+		to {
+			opacity: 1;
+			transform: none;
+		}
+	}
+
+	@media (prefers-reduced-motion: reduce) {
+		.member-slide {
+			animation: none;
+		}
 	}
 </style>

--- a/no_fluxo_frontend_svelte/src/lib/components/home/SobreNosSection.svelte
+++ b/no_fluxo_frontend_svelte/src/lib/components/home/SobreNosSection.svelte
@@ -1,11 +1,14 @@
 <script lang="ts">
-	import { Check } from 'lucide-svelte';
+	import { Check, Gem, Github, Linkedin } from 'lucide-svelte';
+	import { fly } from 'svelte/transition';
+	import { cubicOut } from 'svelte/easing';
 	import MemberCard from './MemberCard.svelte';
 
-	const teamMembers = [
+	const founders = [
 		{
 			name: 'Guilherme Gusmão',
 			githubUsername: 'gusmoles',
+			funcao: 'Interfaces e identidade visual do produto',
 			specialties: ['Frontend', 'UX/UI', 'Design'],
 			linkedin: 'https://www.linkedin.com/in/guilherme-gusmão-nepomuceno-9b44a826a/',
 			email: ''
@@ -13,6 +16,7 @@
 		{
 			name: 'Vitor Marconi',
 			githubUsername: 'Vitor-Trancoso',
+			funcao: 'Fullstack, arquitetura visual e manutenção do produto',
 			specialties: ['Fullstack', 'Design', 'Arquitetura visual'],
 			linkedin: 'https://www.linkedin.com/in/vitor-marconi-4a069524a/',
 			email: ''
@@ -20,6 +24,7 @@
 		{
 			name: 'Gustavo Choueiri',
 			githubUsername: 'staann',
+			funcao: 'IA, automações e pipelines de dados',
 			specialties: ['Inteligência Artificial', 'Automações', 'Engenharia de Dados'],
 			linkedin: 'https://www.linkedin.com/in/gustavochoueiri',
 			email: ''
@@ -27,6 +32,7 @@
 		{
 			name: 'Felipe Pedroza',
 			githubUsername: 'darkymeubem',
+			funcao: 'Banco de dados, ciência de dados e backend',
 			specialties: ['Banco de dados', 'Ciência de dados', 'Fullstack'],
 			linkedin: 'https://www.linkedin.com/in/felipe-lopes-pedroza-74b7a527b/',
 			email: ''
@@ -34,6 +40,7 @@
 		{
 			name: 'Vinícius Pereira',
 			githubUsername: 'Vinicius-Ribeiro04',
+			funcao: 'Frontend e renderização do fluxograma',
 			specialties: ['Frontend', 'Design', 'Canvas'],
 			linkedin: 'https://www.linkedin.com/in/vinicius-ribeiro-6192b2270/',
 			email: ''
@@ -41,6 +48,7 @@
 		{
 			name: 'Arthur Fernandes',
 			githubUsername: 'hisarxt',
+			funcao: 'Qualidade, testes e modelagem de dados',
 			specialties: ['QA Analyst', 'Banco de dados', 'Frontend'],
 			linkedin: 'https://www.linkedin.com/in/artxrz/',
 			email: ''
@@ -48,6 +56,7 @@
 		{
 			name: 'Erick Alves',
 			githubUsername: 'erickaalves',
+			funcao: 'Frontend e condução do Scrum',
 			specialties: ['Frontend', 'Scrum', 'Trafego pago'],
 			linkedin: '',
 			email: ''
@@ -55,6 +64,7 @@
 		{
 			name: 'Arthur Ramalho',
 			githubUsername: 'ArthurNRamalho',
+			funcao: 'Design, documentação e planejamento',
 			specialties: ['Design', 'Documentação', 'Planejamento'],
 			linkedin: '',
 			email: ''
@@ -62,11 +72,73 @@
 		{
 			name: 'Otavio Maya',
 			githubUsername: 'knz13',
+			funcao: 'Infraestrutura, integração e Dockerização',
 			specialties: ['Fullstack', 'Integração', 'Dockerização'],
 			linkedin: 'https://www.linkedin.com/in/otávio-maya-8416931a5/',
 			email: ''
 		}
 	];
+
+	const byName = (a: { name: string }, b: { name: string }) => a.name.localeCompare(b.name, 'pt-BR');
+
+	const maintainers = founders
+		.filter((member) => ['Vitor-Trancoso', 'darkymeubem', 'staann'].includes(member.githubUsername))
+		.sort(byName);
+
+	// menção honrosa: destaque fora do grid, também mantém as linhas alinhadas (8 cards = 2x4)
+	const HONOR_USERNAME = 'knz13';
+	const honorMember = founders.find((member) => member.githubUsername === HONOR_USERNAME)!;
+	const foundersGrid = founders
+		.filter((member) => member.githubUsername !== HONOR_USERNAME)
+		.sort(byName);
+
+	const showcase = [
+		{
+			id: 'atuais',
+			label: 'Time atual',
+			title: 'Quem mantém hoje',
+			description: 'Os desenvolvedores que seguem cuidando do No Fluxo no dia a dia.',
+			role: 'Mantenedor',
+			variant: 'maintainer' as const,
+			members: maintainers,
+			honor: null
+		},
+		{
+			id: 'fundadores',
+			label: 'Fundadores',
+			title: 'Quem começou tudo',
+			description: 'O time original que tirou o No Fluxo do papel em 2025.',
+			role: 'Fundador',
+			variant: 'founder' as const,
+			members: foundersGrid,
+			honor: honorMember
+		}
+	];
+
+	const ROTATION_MS = 9000;
+
+	let activeIndex = $state(0);
+	let direction = $state(1);
+	let paused = $state(false);
+
+	const activeGroup = $derived(showcase[activeIndex]);
+
+	function selectGroup(index: number) {
+		if (index === activeIndex) return;
+		direction = index > activeIndex ? 1 : -1;
+		activeIndex = index;
+	}
+
+	$effect(() => {
+		// lê activeIndex para reiniciar a contagem sempre que o grupo muda (auto ou manual)
+		const current = activeIndex;
+		if (paused) return;
+		const timer = setTimeout(() => {
+			direction = 1;
+			activeIndex = (current + 1) % showcase.length;
+		}, ROTATION_MS);
+		return () => clearTimeout(timer);
+	});
 
 	const features = [
 		{ description: 'Feito por estudantes, pra estudantes da UnB.' },
@@ -132,17 +204,125 @@
 		</div>
 	</div>
 
-	<div class="team-grid">
-		{#each teamMembers as member}
-			<!-- TODO: add instagram={member.instagram} prop -->
-			<MemberCard
-				name={member.name}
-				githubUsername={member.githubUsername}
-				specialties={member.specialties}
-				linkedin={member.linkedin}
-				email={member.email}
-			/>
-		{/each}
+	<!-- svelte-ignore a11y_no_static_element_interactions -->
+	<div
+		class="showcase"
+		onmouseenter={() => (paused = true)}
+		onmouseleave={() => (paused = false)}
+		onfocusin={() => (paused = true)}
+		onfocusout={() => (paused = false)}
+	>
+		<div class="showcase-switch" role="tablist" aria-label="Vitrine da equipe">
+			{#each showcase as group, index}
+				<button
+					class="switch-btn"
+					class:active={activeIndex === index}
+					role="tab"
+					aria-selected={activeIndex === index}
+					onclick={() => selectGroup(index)}
+				>
+					<span>{group.label}</span>
+					<span class="switch-count">{group.members.length}</span>
+				</button>
+			{/each}
+			<span class="switch-thumb" style={`transform: translateX(${activeIndex * 100}%)`}></span>
+		</div>
+
+		<div class="showcase-progress" aria-hidden="true">
+			{#key activeIndex}
+				<span class="progress-bar" class:paused style={`animation-duration: ${ROTATION_MS}ms`}
+				></span>
+			{/key}
+		</div>
+
+		<div class="showcase-stage">
+			{#key activeIndex}
+				<div
+					class="showcase-panel"
+					in:fly={{ x: 40 * direction, duration: 450, easing: cubicOut, delay: 240 }}
+					out:fly={{ x: -40 * direction, duration: 220, easing: cubicOut }}
+				>
+					<header class="showcase-head">
+						<h3>{activeGroup.title}</h3>
+						<p>{activeGroup.description}</p>
+					</header>
+
+					<div class="team-grid" class:compact={activeGroup.members.length <= 3}>
+						{#each activeGroup.members as member, memberIndex}
+							<!-- TODO: add instagram={member.instagram} prop -->
+							<div
+								class="team-grid-item"
+								style={`--stagger: ${Math.min(memberIndex, 8) * 55}ms`}
+							>
+								<MemberCard
+									name={member.name}
+									githubUsername={member.githubUsername}
+									specialties={member.specialties}
+									linkedin={member.linkedin}
+									email={member.email}
+									role={activeGroup.role}
+									funcao={member.funcao}
+									variant={activeGroup.variant}
+								/>
+							</div>
+						{/each}
+					</div>
+
+					{#if activeGroup.honor}
+						<div class="honor-card" style="--stagger: 520ms">
+							<span class="honor-badge">
+								<Gem size={13} />
+								Menção honrosa
+							</span>
+
+							<div class="honor-body">
+								<div class="honor-avatar-wrap">
+									<img
+										src={`https://avatars.githubusercontent.com/${activeGroup.honor.githubUsername}`}
+										alt={activeGroup.honor.name}
+										class="honor-avatar"
+										loading="lazy"
+									/>
+								</div>
+
+								<div class="honor-content">
+									<h4 class="honor-name">{activeGroup.honor.name}</h4>
+									<p class="honor-funcao">{activeGroup.honor.funcao}</p>
+									<p class="honor-text">
+										Foi a nossa salvação em vários momentos. Além do código, entregou conselho,
+										trabalho e esforço quando o projeto mais precisou, e é por isso que esse card é
+										de diamante.
+									</p>
+
+									<div class="honor-tags">
+										{#each activeGroup.honor.specialties as specialty}
+											<span class="honor-tag">{specialty}</span>
+										{/each}
+									</div>
+
+									<div class="honor-links">
+										<a
+											href={`https://github.com/${activeGroup.honor.githubUsername}`}
+											target="_blank"
+											rel="noopener noreferrer"
+										>
+											<Github size={15} />
+											@{activeGroup.honor.githubUsername}
+										</a>
+										{#if activeGroup.honor.linkedin}
+											<a href={activeGroup.honor.linkedin} target="_blank" rel="noopener noreferrer">
+												<Linkedin size={15} />
+												LinkedIn
+											</a>
+										{/if}
+									</div>
+								</div>
+							</div>
+						</div>
+					{/if}
+				</div>
+			{/key}
+		</div>
 	</div>
 </section>
 
@@ -221,6 +401,141 @@
 		margin-top: 2px;
 	}
 
+	.showcase {
+		max-width: 1120px;
+		margin: 0 auto;
+	}
+
+	.showcase-switch {
+		position: relative;
+		display: grid;
+		grid-template-columns: repeat(2, 1fr);
+		gap: 0.25rem;
+		width: min(100%, 380px);
+		margin: 0 auto;
+		padding: 0.3rem;
+		border-radius: 999px;
+		border: 1px solid hsl(0 0% 100% / 0.08);
+		background: hsl(var(--card) / 0.6);
+		box-shadow: inset 0 1px 0 hsl(0 0% 100% / 0.05);
+	}
+
+	.switch-btn {
+		position: relative;
+		z-index: 1;
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		gap: 0.45rem;
+		padding: 0.55rem 0.9rem;
+		border: none;
+		border-radius: 999px;
+		background: transparent;
+		color: hsl(var(--muted-foreground));
+		font-size: clamp(0.75rem, 1.4vw, 0.875rem);
+		font-weight: 600;
+		letter-spacing: -0.01em;
+		cursor: pointer;
+		transition: color 0.25s ease;
+	}
+
+	.switch-btn:hover {
+		color: hsl(var(--foreground));
+	}
+
+	.switch-btn.active {
+		color: hsl(var(--foreground));
+	}
+
+	.switch-count {
+		min-width: 20px;
+		padding: 0.05rem 0.35rem;
+		border-radius: 999px;
+		background: hsl(0 0% 100% / 0.1);
+		font-size: 0.6875rem;
+		font-weight: 700;
+	}
+
+	.switch-btn.active .switch-count {
+		background: hsl(var(--primary) / 0.35);
+	}
+
+	.switch-thumb {
+		position: absolute;
+		top: 0.3rem;
+		left: 0.3rem;
+		width: calc(50% - 0.425rem);
+		height: calc(100% - 0.6rem);
+		border-radius: 999px;
+		border: 1px solid hsl(var(--primary) / 0.35);
+		background: linear-gradient(
+			135deg,
+			hsl(var(--primary) / 0.32) 0%,
+			hsl(var(--primary) / 0.12) 100%
+		);
+		box-shadow: 0 0 18px hsl(var(--primary) / 0.25);
+		transition: transform 0.45s cubic-bezier(0.4, 0, 0.2, 1);
+	}
+
+	.showcase-progress {
+		width: min(100%, 380px);
+		height: 2px;
+		margin: 0.75rem auto 1.75rem;
+		border-radius: 999px;
+		background: hsl(0 0% 100% / 0.07);
+		overflow: hidden;
+	}
+
+	.progress-bar {
+		display: block;
+		height: 100%;
+		width: 100%;
+		transform-origin: left center;
+		border-radius: 999px;
+		background: linear-gradient(90deg, hsl(var(--primary) / 0.2), hsl(var(--primary)));
+		animation: showcase-progress linear forwards;
+	}
+
+	.progress-bar.paused {
+		animation-play-state: paused;
+	}
+
+	@keyframes showcase-progress {
+		from {
+			transform: scaleX(0);
+		}
+		to {
+			transform: scaleX(1);
+		}
+	}
+
+	.showcase-stage {
+		display: grid;
+	}
+
+	.showcase-panel {
+		grid-area: 1 / 1;
+	}
+
+	.showcase-head {
+		text-align: center;
+		margin-bottom: 1.5rem;
+	}
+
+	.showcase-head h3 {
+		color: hsl(var(--foreground));
+		font-size: clamp(1.0625rem, 2.2vw, 1.375rem);
+		font-weight: 700;
+		letter-spacing: -0.02em;
+		margin: 0 0 0.35rem;
+	}
+
+	.showcase-head p {
+		color: hsl(var(--muted-foreground));
+		font-size: clamp(0.8125rem, 1.4vw, 0.9375rem);
+		margin: 0;
+	}
+
 	.team-grid {
 		display: grid;
 		grid-template-columns: repeat(2, 1fr);
@@ -229,10 +544,224 @@
 		margin: 0 auto;
 	}
 
+	.team-grid-item {
+		animation: card-in 0.5s cubic-bezier(0.4, 0, 0.2, 1) backwards;
+		animation-delay: calc(120ms + var(--stagger, 0ms));
+	}
+
+	/* menção honrosa — card "diamante" */
+	.honor-card {
+		position: relative;
+		max-width: 1120px;
+		margin: 1.5rem auto 0;
+		padding: 1.5rem;
+		border-radius: 18px;
+		border: 1.5px solid rgba(168, 226, 255, 0.55);
+		background:
+			radial-gradient(120% 140% at 12% 0%, rgba(150, 220, 255, 0.14) 0%, transparent 55%),
+			radial-gradient(120% 140% at 100% 100%, rgba(196, 168, 255, 0.14) 0%, transparent 55%),
+			hsl(var(--card) / 0.72);
+		box-shadow:
+			0 0 0 1px rgba(168, 226, 255, 0.16),
+			0 18px 48px rgba(90, 180, 255, 0.14),
+			inset 0 1px 0 rgba(255, 255, 255, 0.08);
+		overflow: hidden;
+		animation: card-in 0.55s cubic-bezier(0.4, 0, 0.2, 1) backwards;
+		animation-delay: calc(120ms + var(--stagger, 0ms));
+	}
+
+	/* brilho de diamante atravessando o card */
+	.honor-card::before {
+		content: '';
+		position: absolute;
+		top: -60%;
+		left: -30%;
+		width: 40%;
+		height: 220%;
+		pointer-events: none;
+		background: linear-gradient(
+			100deg,
+			transparent 0%,
+			rgba(255, 255, 255, 0.16) 45%,
+			rgba(190, 235, 255, 0.28) 50%,
+			rgba(255, 255, 255, 0.16) 55%,
+			transparent 100%
+		);
+		transform: rotate(8deg);
+		animation: diamond-shine 6.5s ease-in-out infinite;
+	}
+
+	@keyframes diamond-shine {
+		0%,
+		62% {
+			transform: translateX(0) rotate(8deg);
+			opacity: 0;
+		}
+		66% {
+			opacity: 1;
+		}
+		100% {
+			transform: translateX(420%) rotate(8deg);
+			opacity: 0;
+		}
+	}
+
+	.honor-badge {
+		position: relative;
+		display: inline-flex;
+		align-items: center;
+		gap: 0.4rem;
+		padding: 0.3rem 0.7rem;
+		border-radius: 999px;
+		border: 1px solid rgba(168, 226, 255, 0.5);
+		background: linear-gradient(135deg, rgba(168, 226, 255, 0.24), rgba(196, 168, 255, 0.14));
+		color: #d8f1ff;
+		font-size: 0.75rem;
+		font-weight: 700;
+		letter-spacing: 0.02em;
+	}
+
+	.honor-body {
+		position: relative;
+		display: flex;
+		flex-direction: column;
+		align-items: center;
+		gap: 1.25rem;
+		margin-top: 1rem;
+		text-align: center;
+	}
+
+	.honor-avatar-wrap {
+		width: 112px;
+		height: 112px;
+		flex-shrink: 0;
+		border-radius: 50%;
+		padding: 3px;
+		background: linear-gradient(135deg, #bfe9ff 0%, #ffffff 35%, #c9b8ff 70%, #8fd7ff 100%);
+		box-shadow: 0 0 24px rgba(150, 220, 255, 0.35);
+	}
+
+	.honor-avatar {
+		width: 100%;
+		height: 100%;
+		border-radius: 50%;
+		object-fit: cover;
+		background: #374151;
+		display: block;
+	}
+
+	.honor-name {
+		color: hsl(var(--foreground));
+		font-size: clamp(1.0625rem, 2vw, 1.375rem);
+		font-weight: 800;
+		letter-spacing: -0.02em;
+		margin: 0;
+	}
+
+	.honor-funcao {
+		color: #cfeaff;
+		font-size: clamp(0.8125rem, 1.4vw, 0.9375rem);
+		font-weight: 600;
+		margin: 0.15rem 0 0.5rem;
+	}
+
+	.honor-text {
+		color: hsl(var(--muted-foreground));
+		font-size: clamp(0.8125rem, 1.4vw, 0.9375rem);
+		line-height: 1.65;
+		margin: 0 0 0.85rem;
+		max-width: 62ch;
+	}
+
+	.honor-tags {
+		display: flex;
+		flex-wrap: wrap;
+		justify-content: center;
+		gap: 0.4rem;
+		margin-bottom: 0.85rem;
+	}
+
+	.honor-tag {
+		padding: 0.25rem 0.65rem;
+		border-radius: 999px;
+		border: 1px solid rgba(168, 226, 255, 0.3);
+		background: rgba(168, 226, 255, 0.08);
+		color: #e6f6ff;
+		font-size: 0.75rem;
+		font-weight: 500;
+	}
+
+	.honor-links {
+		display: flex;
+		flex-wrap: wrap;
+		justify-content: center;
+		gap: 1rem;
+	}
+
+	.honor-links a {
+		display: inline-flex;
+		align-items: center;
+		gap: 0.35rem;
+		color: #e6f6ff;
+		font-size: 0.8125rem;
+		text-decoration: none;
+	}
+
+	.honor-links a:hover {
+		text-decoration: underline;
+	}
+
+	@media (min-width: 768px) {
+		.honor-card {
+			padding: 1.75rem 2rem;
+		}
+
+		.honor-body {
+			flex-direction: row;
+			align-items: center;
+			text-align: left;
+			gap: 1.75rem;
+		}
+
+		.honor-tags,
+		.honor-links {
+			justify-content: flex-start;
+		}
+	}
+
+	@keyframes card-in {
+		from {
+			opacity: 0;
+			transform: translateY(14px) scale(0.97);
+		}
+		to {
+			opacity: 1;
+			transform: none;
+		}
+	}
+
 	@media (min-width: 768px) {
 		.team-grid {
 			grid-template-columns: repeat(4, 1fr);
 			gap: 1.5rem;
+		}
+
+		.team-grid.compact {
+			grid-template-columns: repeat(auto-fit, minmax(0, 260px));
+			justify-content: center;
+		}
+	}
+
+	@media (prefers-reduced-motion: reduce) {
+		.team-grid-item,
+		.progress-bar,
+		.honor-card,
+		.honor-card::before {
+			animation: none;
+		}
+
+		.switch-thumb {
+			transition: none;
 		}
 	}
 </style>


### PR DESCRIPTION
A seção "Sobre nós" listava só o time fundador num grid estático. Vira uma vitrine com dois grupos alternando automaticamente (9s, pausa no hover): "Time atual" (Vitor Marconi, Felipe Pedroza e Gustavo Choueiri) e "Fundadores" (os 9 originais), com alternador em pílula, barra de progresso e transição de slide entre os painéis.

- bordas de honra: dourada + anel no avatar para fundadores, roxa neon para mantenedores; papel exibido no card (Fundador/Mantenedor)
- cada membro ganhou campo `funcao` (o que faz no projeto) exibido sob o nome — divulga a atuação de cada um; slides do card ficam estáticos, navegáveis pelas setas/bolinhas
- menção honrosa: Otávio Maya sai do grid e ganha card "diamante" de largura total (borda iridescente, brilho periódico, texto de homenagem, tags e links) — também alinha o grid em 2 linhas de 4
- ordem alfabética (pt-BR) nos dois grupos; altura dos cards padronizada; prefers-reduced-motion respeitado em todas as animações

## 📌 Descrição

Descreva brevemente o que foi feito nesta PR.

## 🔗 Issue Relacionada

Closes #

## ✅ Tipo de Mudança

- [ ] Correção de bug
- [ ] Nova funcionalidade
- [ ] Refatoração
- [ ] Documentação

## 🔍 Checklist

- [ ] Testes criados/atualizados
- [ ] Documentação atualizada (se necessário)
- [ ] PR revisada e pronta para merge
