### PR TITLE
feat(montador-grade): onboarding guiado, tooltips e layout com calend…

### DIFF
--- a/no_fluxo_frontend_svelte/src/lib/components/onboarding/HelpTip.svelte
+++ b/no_fluxo_frontend_svelte/src/lib/components/onboarding/HelpTip.svelte
@@ -1,0 +1,71 @@
+<script lang="ts">
+	import * as Tooltip from '$lib/components/ui/tooltip';
+	import { HelpCircle } from 'lucide-svelte';
+	import type { Snippet } from 'svelte';
+
+	/**
+	 * Dica de ajuda no padrão do DS. Sem `children`, renderiza o ícone "?" padrão;
+	 * com `children`, vira wrapper de qualquer gatilho (botão, chip, título).
+	 */
+	let {
+		text,
+		title = '',
+		side = 'top',
+		children,
+		class: className = ''
+	}: {
+		text: string;
+		title?: string;
+		side?: 'top' | 'bottom' | 'left' | 'right';
+		children?: Snippet;
+		class?: string;
+	} = $props();
+</script>
+
+<Tooltip.Provider delayDuration={200}>
+	<Tooltip.Root>
+		{#if children}
+			<!--
+				Com gatilho próprio o Trigger vira <span> (snippet `child`): o conteúdo
+				normalmente já é um <button>/<a>, e botão dentro de botão é HTML inválido
+				— o navegador desmonta a árvore e o clique original para de funcionar.
+			-->
+			<Tooltip.Trigger>
+				{#snippet child({ props })}
+					<span {...props} class={`help-trigger-wrap ${className}`}>
+						{@render children()}
+					</span>
+				{/snippet}
+			</Tooltip.Trigger>
+		{:else}
+			<Tooltip.Trigger class={`help-trigger ${className}`} aria-label={title || text}>
+				<HelpCircle class="h-3.5 w-3.5 text-white/40 transition-colors hover:text-white/80" />
+			</Tooltip.Trigger>
+		{/if}
+		<Tooltip.Content
+			{side}
+			sideOffset={6}
+			class="nf-card-surface z-[140] max-w-[260px] border-white/12 bg-zinc-950/95 px-3 py-2 text-white shadow-xl backdrop-blur-md"
+			arrowClasses="bg-zinc-950 border-white/12"
+		>
+			{#if title}
+				<p class="mb-0.5 text-[12px] font-semibold text-white">{title}</p>
+			{/if}
+			<p class="text-[11px] leading-relaxed text-white/70">{text}</p>
+		</Tooltip.Content>
+	</Tooltip.Root>
+</Tooltip.Provider>
+
+<style>
+	:global(.help-trigger) {
+		display: inline-flex;
+		align-items: center;
+		justify-content: center;
+		cursor: help;
+	}
+
+	:global(.help-trigger-wrap) {
+		display: inline-flex;
+		align-items: center;
+	}
+</style>

--- a/no_fluxo_frontend_svelte/src/lib/components/onboarding/OnboardingTour.svelte
+++ b/no_fluxo_frontend_svelte/src/lib/components/onboarding/OnboardingTour.svelte
@@ -1,0 +1,455 @@
+<script lang="ts">
+	import { tourStore } from './tour.store.svelte';
+	import { Button } from '$lib/components/ui/button';
+	import { ArrowLeft, ArrowRight, Check, Sparkles, X } from 'lucide-svelte';
+	import { fade, fly } from 'svelte/transition';
+	import { cubicOut } from 'svelte/easing';
+	import { untrack } from 'svelte';
+	import { toast } from 'svelte-sonner';
+
+	/**
+	 * Coach marks com spotlight: escurece a página inteira, recorta o elemento do
+	 * passo atual e ancora um card ao lado dele. Passo sem alvo (ou com alvo que
+	 * não existe na tela) vira card centralizado, então o tour nunca trava.
+	 */
+
+	interface Rect {
+		top: number;
+		left: number;
+		width: number;
+		height: number;
+	}
+
+	const MARGEM = 14;
+	const CARD_W = 340;
+
+	// Só `alvo` e `cardPos` são reativos: são o que o template desenha. Medidas de
+	// apoio ficam fora do grafo — lê-las e escrevê-las dentro do mesmo efeito criaria
+	// um laço de atualização (o Svelte aborta e a reatividade da página inteira morre).
+	let alvo = $state<Rect | null>(null);
+	let cardPos = $state<{ top: number; left: number } | null>(null);
+	let cardEl = $state<HTMLElement | null>(null);
+	let viewport = { w: 0, h: 0 };
+
+	const step = $derived(tourStore.stepAtual);
+
+	function medir(): void {
+		const s = untrack(() => tourStore.stepAtual);
+		if (!s) return;
+
+		viewport = { w: window.innerWidth, h: window.innerHeight };
+
+		const el = s.target ? document.querySelector<HTMLElement>(`[data-tour="${s.target}"]`) : null;
+		if (!el) {
+			alvo = null;
+			cardPos = null;
+			return;
+		}
+
+		const pad = s.padding ?? 8;
+		const r = el.getBoundingClientRect();
+		alvo = {
+			top: r.top - pad,
+			left: r.left - pad,
+			width: r.width + pad * 2,
+			height: r.height + pad * 2
+		};
+		cardPos = posicionarCard(alvo, s.side ?? 'bottom');
+	}
+
+	/** Escolhe o lado com espaço; cai para o oposto e, no aperto, centraliza embaixo. */
+	function posicionarCard(r: Rect, preferido: 'top' | 'bottom' | 'left' | 'right') {
+		const card = untrack(() => cardEl);
+		const alturaCard = card?.offsetHeight ?? 210;
+		const larguraCard = card?.offsetWidth ?? CARD_W;
+		const { w, h } = viewport;
+
+		const cabe = {
+			top: r.top - MARGEM - alturaCard > 8,
+			bottom: r.top + r.height + MARGEM + alturaCard < h - 8,
+			left: r.left - MARGEM - larguraCard > 8,
+			right: r.left + r.width + MARGEM + larguraCard < w - 8
+		};
+
+		const oposto = { top: 'bottom', bottom: 'top', left: 'right', right: 'left' } as const;
+		const ordem = [preferido, oposto[preferido], 'bottom', 'top', 'right', 'left'] as const;
+		const lado = ordem.find((l) => cabe[l]) ?? 'bottom';
+
+		let top: number;
+		let left: number;
+		if (lado === 'top') {
+			top = r.top - MARGEM - alturaCard;
+			left = r.left + r.width / 2 - larguraCard / 2;
+		} else if (lado === 'bottom') {
+			top = r.top + r.height + MARGEM;
+			left = r.left + r.width / 2 - larguraCard / 2;
+		} else if (lado === 'left') {
+			top = r.top + r.height / 2 - alturaCard / 2;
+			left = r.left - MARGEM - larguraCard;
+		} else {
+			top = r.top + r.height / 2 - alturaCard / 2;
+			left = r.left + r.width + MARGEM;
+		}
+
+		return {
+			top: Math.min(Math.max(top, 8), Math.max(8, h - alturaCard - 8)),
+			left: Math.min(Math.max(left, 8), Math.max(8, w - larguraCard - 8))
+		};
+	}
+
+	// Reposiciona a cada troca de passo — com o alvo já rolado para a tela.
+	// IMPORTANTE: nenhuma escrita de $state no corpo do efeito. Ao fechar, o passo
+	// vira null durante o desmonte do bloco; escrever estado aqui nesse momento
+	// interrompia a remoção do overlay, que ficava invisível bloqueando a página.
+	// medir() (via rAF/timeout) já zera alvo/cardPos quando o passo não tem alvo.
+	$effect(() => {
+		const s = tourStore.stepAtual;
+		if (!s) return;
+
+		const el = s.target ? document.querySelector<HTMLElement>(`[data-tour="${s.target}"]`) : null;
+		el?.scrollIntoView({ block: 'center', behavior: 'smooth' });
+
+		// Todas as medições saem do efeito (rAF/timeout): medir() escreve estado, e
+		// fazer isso de dentro do efeito que observa o passo realimenta o grafo.
+		const raf = requestAnimationFrame(medir);
+		// Uma medida depois do scroll suave e outra com o card já montado — a altura
+		// real dele muda de que lado ele cabe.
+		const t1 = setTimeout(medir, 80);
+		const t2 = setTimeout(medir, 440);
+		return () => {
+			cancelAnimationFrame(raf);
+			clearTimeout(t1);
+			clearTimeout(t2);
+		};
+	});
+
+	$effect(() => {
+		if (!tourStore.aberto) return;
+		const onChange = () => medir();
+		window.addEventListener('resize', onChange);
+		window.addEventListener('scroll', onChange, true);
+		return () => {
+			window.removeEventListener('resize', onChange);
+			window.removeEventListener('scroll', onChange, true);
+		};
+	});
+
+	/** "Pular" é saída explícita: persiste e ensina onde reabrir. */
+	function pular(): void {
+		tourStore.concluir();
+		toast.info('Sem problema! Reveja o passo a passo quando quiser em "Como funciona", no topo.');
+	}
+
+	function onKeydown(event: KeyboardEvent): void {
+		if (!tourStore.aberto) return;
+		if (event.key === 'Escape') {
+			// Dispensa acidental: fecha sem gravar — o tour volta na próxima visita.
+			event.preventDefault();
+			tourStore.fechar();
+		} else if (event.key === 'ArrowRight' || event.key === 'Enter') {
+			event.preventDefault();
+			tourStore.proximo();
+		} else if (event.key === 'ArrowLeft') {
+			event.preventDefault();
+			tourStore.anterior();
+		}
+	}
+</script>
+
+<svelte:window onkeydown={onKeydown} />
+
+{#if tourStore.aberto && step}
+	<!--
+		Véu + recorte. Clique fora FECHA sem marcar como visto: no celular esse é o
+		gesto natural de dispensar, e avançar aqui queimava o tour inteiro sem o
+		aluno ler nada — ele volta a se oferecer na próxima visita.
+	-->
+	<!-- Só transição de ENTRADA: outros (out:) neste bloco já falharam em completar
+	     e deixavam o overlay invisível preso no DOM, bloqueando a página inteira.
+	     Remoção síncrona é a opção segura para um véu fixed de tela cheia. -->
+	<div
+		class="tour-overlay"
+		in:fade={{ duration: 220 }}
+		role="presentation"
+		onclick={() => tourStore.fechar()}
+	>
+		{#if alvo}
+			<div
+				class="tour-spotlight"
+				style={`top:${alvo.top}px; left:${alvo.left}px; width:${alvo.width}px; height:${alvo.height}px;`}
+			></div>
+			<div
+				class="tour-pulse"
+				style={`top:${alvo.top}px; left:${alvo.left}px; width:${alvo.width}px; height:${alvo.height}px;`}
+			></div>
+		{:else}
+			<div class="tour-veil"></div>
+		{/if}
+	</div>
+
+	<div
+		bind:this={cardEl}
+		class="tour-card nf-card-surface"
+		class:tour-card-centered={!cardPos}
+		style={cardPos ? `top:${cardPos.top}px; left:${cardPos.left}px;` : undefined}
+		in:fly={{ y: 12, duration: 320, easing: cubicOut }}
+		role="dialog"
+		aria-modal="true"
+		aria-label={step.title}
+	>
+		<header class="tour-card-head">
+			<span class="tour-step-badge">
+				<Sparkles class="h-3 w-3" />
+				Passo {tourStore.index + 1} de {tourStore.total}
+			</span>
+			<button
+				type="button"
+				class="tour-close"
+				onclick={() => tourStore.fechar()}
+				aria-label="Fechar tour"
+			>
+				<X class="h-3.5 w-3.5" />
+			</button>
+		</header>
+
+		<h2 class="tour-title">{step.title}</h2>
+		<p class="tour-desc">{step.description}</p>
+		{#if step.hint}
+			<p class="tour-hint">{step.hint}</p>
+		{/if}
+
+		<div class="tour-dots" role="tablist" aria-label="Progresso do tour">
+			{#each tourStore.steps as s, i (s.title)}
+				<button
+					type="button"
+					class="tour-dot"
+					class:active={i === tourStore.index}
+					class:done={i < tourStore.index}
+					onclick={() => tourStore.irPara(i)}
+					aria-label={`Ir para o passo ${i + 1}: ${s.title}`}
+					aria-selected={i === tourStore.index}
+					role="tab"
+				></button>
+			{/each}
+		</div>
+
+		<footer class="tour-actions">
+			<Button variant="ghost" size="sm" class="text-white/50" onclick={pular}>Pular</Button>
+			<div class="tour-actions-right">
+				{#if !tourStore.isPrimeiro}
+					<Button variant="outline" size="sm" onclick={() => tourStore.anterior()}>
+						<ArrowLeft class="h-3.5 w-3.5" />
+						Voltar
+					</Button>
+				{/if}
+				<Button size="sm" class="nf-cta-glow-hover" onclick={() => tourStore.proximo()}>
+					{#if tourStore.isUltimo}
+						<Check class="h-3.5 w-3.5" />
+						Entendi!
+					{:else}
+						Próximo
+						<ArrowRight class="h-3.5 w-3.5" />
+					{/if}
+				</Button>
+			</div>
+		</footer>
+	</div>
+{/if}
+
+<style>
+	.tour-overlay {
+		position: fixed;
+		inset: 0;
+		z-index: 120;
+	}
+
+	.tour-veil {
+		position: absolute;
+		inset: 0;
+		background: hsl(240 14% 3% / 0.72);
+		backdrop-filter: blur(2px);
+		-webkit-backdrop-filter: blur(2px);
+	}
+
+	/* O "buraco" do spotlight é a própria sombra gigante ao redor do recorte. */
+	.tour-spotlight {
+		position: absolute;
+		border-radius: 16px;
+		box-shadow:
+			0 0 0 9999px hsl(240 14% 3% / 0.72),
+			inset 0 0 0 1.5px hsl(var(--primary) / 0.65);
+		transition:
+			top 0.42s cubic-bezier(0.4, 0, 0.2, 1),
+			left 0.42s cubic-bezier(0.4, 0, 0.2, 1),
+			width 0.42s cubic-bezier(0.4, 0, 0.2, 1),
+			height 0.42s cubic-bezier(0.4, 0, 0.2, 1);
+		pointer-events: none;
+	}
+
+	.tour-pulse {
+		position: absolute;
+		border-radius: 16px;
+		pointer-events: none;
+		box-shadow: 0 0 0 0 hsl(var(--primary) / 0.45);
+		animation: tour-pulse 2.4s ease-out infinite;
+		transition:
+			top 0.42s cubic-bezier(0.4, 0, 0.2, 1),
+			left 0.42s cubic-bezier(0.4, 0, 0.2, 1),
+			width 0.42s cubic-bezier(0.4, 0, 0.2, 1),
+			height 0.42s cubic-bezier(0.4, 0, 0.2, 1);
+	}
+
+	@keyframes tour-pulse {
+		0% {
+			box-shadow:
+				0 0 0 0 hsl(var(--primary) / 0.4),
+				0 0 22px hsl(var(--primary) / 0.25);
+		}
+		70% {
+			box-shadow:
+				0 0 0 12px hsl(var(--primary) / 0),
+				0 0 22px hsl(var(--primary) / 0.1);
+		}
+		100% {
+			box-shadow:
+				0 0 0 0 hsl(var(--primary) / 0),
+				0 0 22px hsl(var(--primary) / 0);
+		}
+	}
+
+	.tour-card {
+		position: fixed;
+		z-index: 130;
+		width: min(340px, calc(100vw - 2rem));
+		padding: 1rem 1.1rem 0.9rem;
+		box-shadow:
+			inset 0 1px 0 hsl(0 0% 100% / 0.09),
+			0 0 0 1px hsl(var(--primary) / 0.18),
+			0 24px 60px hsl(0 0% 0% / 0.6),
+			0 0 60px hsl(var(--primary) / 0.12);
+	}
+
+	.tour-card-centered {
+		top: 50%;
+		left: 50%;
+		transform: translate(-50%, -50%);
+	}
+
+	.tour-card-head {
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+		gap: 0.5rem;
+		margin-bottom: 0.6rem;
+	}
+
+	.tour-step-badge {
+		display: inline-flex;
+		align-items: center;
+		gap: 0.3rem;
+		padding: 0.2rem 0.55rem;
+		border-radius: 999px;
+		border: 1px solid hsl(var(--primary) / 0.3);
+		background: hsl(var(--primary) / 0.14);
+		color: hsl(var(--primary-foreground));
+		font-size: 0.6875rem;
+		font-weight: 600;
+		letter-spacing: 0.01em;
+	}
+
+	.tour-close {
+		display: inline-flex;
+		align-items: center;
+		justify-content: center;
+		width: 24px;
+		height: 24px;
+		border-radius: 8px;
+		border: none;
+		background: transparent;
+		color: hsl(var(--muted-foreground));
+		cursor: pointer;
+		transition: background 0.18s ease;
+	}
+
+	.tour-close:hover {
+		background: hsl(0 0% 100% / 0.08);
+		color: hsl(var(--foreground));
+	}
+
+	.tour-title {
+		color: hsl(var(--foreground));
+		font-size: 1rem;
+		font-weight: 700;
+		letter-spacing: -0.015em;
+		margin: 0 0 0.35rem;
+	}
+
+	.tour-desc {
+		color: hsl(var(--muted-foreground));
+		font-size: 0.8125rem;
+		line-height: 1.6;
+		margin: 0;
+	}
+
+	.tour-hint {
+		display: flex;
+		gap: 0.4rem;
+		margin: 0.6rem 0 0;
+		padding: 0.5rem 0.65rem;
+		border-radius: 10px;
+		border: 1px solid hsl(var(--ai) / 0.22);
+		background: hsl(var(--ai-soft) / 0.4);
+		color: hsl(var(--ai) / 0.92);
+		font-size: 0.75rem;
+		line-height: 1.5;
+	}
+
+	.tour-dots {
+		display: flex;
+		gap: 0.3rem;
+		margin: 0.9rem 0 0.75rem;
+	}
+
+	.tour-dot {
+		width: 18px;
+		height: 4px;
+		border-radius: 999px;
+		border: none;
+		padding: 0;
+		cursor: pointer;
+		background: hsl(0 0% 100% / 0.14);
+		transition:
+			background 0.25s ease,
+			width 0.25s ease;
+	}
+
+	.tour-dot.done {
+		background: hsl(var(--primary) / 0.45);
+	}
+
+	.tour-dot.active {
+		width: 26px;
+		background: hsl(var(--primary));
+	}
+
+	.tour-actions {
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+		gap: 0.5rem;
+	}
+
+	.tour-actions-right {
+		display: flex;
+		align-items: center;
+		gap: 0.4rem;
+	}
+
+	@media (prefers-reduced-motion: reduce) {
+		.tour-spotlight,
+		.tour-pulse {
+			transition: none;
+			animation: none;
+		}
+	}
+</style>

--- a/no_fluxo_frontend_svelte/src/lib/components/onboarding/tour.store.svelte.ts
+++ b/no_fluxo_frontend_svelte/src/lib/components/onboarding/tour.store.svelte.ts
@@ -1,0 +1,107 @@
+/**
+ * Estado do onboarding guiado (coach marks).
+ *
+ * Fica fora do componente porque o tour é aberto de vários lugares: sozinho na
+ * primeira visita, pelo botão "Como funciona" do cabeçalho e pelo menu de ajuda.
+ */
+
+export interface TourStep {
+	/** Valor de `data-tour` do elemento destacado. Sem alvo = card centralizado. */
+	target?: string;
+	title: string;
+	description: string;
+	/** Dica extra, em tom mais leve (aparece com marcador). */
+	hint?: string;
+	/** Lado preferido do card em relação ao alvo. */
+	side?: 'top' | 'bottom' | 'left' | 'right';
+	/** Espaço extra no recorte do spotlight (px). */
+	padding?: number;
+}
+
+function chaveStorage(id: string): string {
+	return `nofluxo:tour:${id}`;
+}
+
+/**
+ * Já concluiu/pulou este tour antes? Storage bloqueado (aba anônima, Safari
+ * restrito) conta como "não" — melhor repetir o tour a cada visita do que
+ * nunca mostrá-lo para quem mais precisa. `startSeNovo` só roda no browser,
+ * então retornar false sem localStorage não afeta SSR.
+ */
+export function tourConcluido(id: string): boolean {
+	if (typeof localStorage === 'undefined') return false;
+	try {
+		return localStorage.getItem(chaveStorage(id)) === 'done';
+	} catch {
+		return false;
+	}
+}
+
+function marcarConcluido(id: string): void {
+	if (typeof localStorage === 'undefined') return;
+	try {
+		localStorage.setItem(chaveStorage(id), 'done');
+	} catch {
+		/* modo privado / storage cheio: o tour só volta a aparecer na próxima visita */
+	}
+}
+
+class TourStore {
+	id = $state<string | null>(null);
+	steps = $state<TourStep[]>([]);
+	index = $state(0);
+
+	readonly aberto = $derived(this.id !== null);
+	readonly stepAtual = $derived<TourStep | null>(this.steps[this.index] ?? null);
+	readonly total = $derived(this.steps.length);
+	readonly isPrimeiro = $derived(this.index === 0);
+	readonly isUltimo = $derived(this.index >= this.steps.length - 1);
+
+	start(id: string, steps: TourStep[], fromStep = 0): void {
+		if (steps.length === 0) return;
+		this.id = id;
+		this.steps = steps;
+		this.index = Math.min(Math.max(fromStep, 0), steps.length - 1);
+	}
+
+	/** Abre só se o usuário ainda não viu — usado no primeiro acesso à página. */
+	startSeNovo(id: string, steps: TourStep[]): void {
+		if (tourConcluido(id)) return;
+		this.start(id, steps);
+	}
+
+	proximo(): void {
+		if (this.isUltimo) {
+			this.concluir();
+			return;
+		}
+		this.index += 1;
+	}
+
+	anterior(): void {
+		if (this.index > 0) this.index -= 1;
+	}
+
+	irPara(index: number): void {
+		if (index < 0 || index >= this.steps.length) return;
+		this.index = index;
+	}
+
+	/**
+	 * Fecha marcando como visto — só para saídas explícitas ("Entendi!" e
+	 * "Pular"). Dispensas acidentais (clique fora, X, Esc) usam fechar(), que
+	 * não persiste: o tour volta a se oferecer na próxima visita.
+	 */
+	concluir(): void {
+		if (this.id) marcarConcluido(this.id);
+		this.fechar();
+	}
+
+	fechar(): void {
+		this.id = null;
+		this.steps = [];
+		this.index = 0;
+	}
+}
+
+export const tourStore = new TourStore();

--- a/no_fluxo_frontend_svelte/src/lib/components/planejamento/AssistenteChatFab.svelte
+++ b/no_fluxo_frontend_svelte/src/lib/components/planejamento/AssistenteChatFab.svelte
@@ -180,6 +180,7 @@
 		class="fixed z-[90] flex items-center justify-center border border-pink-500/50 bg-[#1e1e24]/80 shadow-[0_8px_30px_rgba(236,72,153,0.3)] backdrop-blur-md transition-all duration-300 hover:scale-105 hover:border-pink-400 hover:bg-[#2a2a32] active:scale-95
 			{isMobile ? 'bottom-4 right-4 h-14 w-14 rounded-full' : 'bottom-6 right-6 h-12 w-12 rounded-xl'}"
 		aria-label="Abrir assistente IA"
+		data-tour="assistente-ia"
 		in:scale={{ start: 0.5, duration: 400, easing: backOut, delay: 100 }}
 		out:scale={{ start: 0.5, duration: 200, easing: cubicOut }}
 	>

--- a/no_fluxo_frontend_svelte/src/lib/components/planejamento/GradeResumo.svelte
+++ b/no_fluxo_frontend_svelte/src/lib/components/planejamento/GradeResumo.svelte
@@ -2,6 +2,7 @@
 	import { gradeStore } from '$lib/stores/grade.store.svelte';
 	import { formatHorarioSigaa, compactarFaixasHorarias } from '$lib/utils/sigaa';
 	import { X, ListChecks, TriangleAlert } from 'lucide-svelte';
+	import HelpTip from '$lib/components/onboarding/HelpTip.svelte';
 
 	function nomeMateria(codigo: string): string {
 		return gradeStore.pool.find((m) => m.codigo === codigo)?.nome ?? codigo;
@@ -16,10 +17,14 @@
 	}
 </script>
 
-<section class="rounded-2xl border border-white/10 bg-zinc-950/78 p-3">
+<section class="rounded-2xl border border-white/10 bg-zinc-950/78 p-3" data-tour="resumo">
 	<header class="mb-2.5 flex items-center justify-between border-b border-white/10 pb-2">
 		<p class="flex items-center gap-1.5 text-xs font-semibold uppercase tracking-[0.12em] text-white/80">
-			<ListChecks class="h-3.5 w-3.5" /> Resumo
+			<ListChecks class="h-3.5 w-3.5" /> 4 · Resumo
+			<HelpTip
+				title="Sua grade em lista"
+				text="Tudo que está no calendário aparece aqui com turma, professor e horário. Passe o mouse para destacar a matéria na grade e use o X para tirá-la."
+			/>
 		</p>
 		<span class="rounded-full border border-white/10 bg-white/5 px-2 py-0.5 text-[10px] text-white/60">
 			{gradeStore.creditosSelecionados} créditos

--- a/no_fluxo_frontend_svelte/src/lib/components/planejamento/MateriaSearchAdd.svelte
+++ b/no_fluxo_frontend_svelte/src/lib/components/planejamento/MateriaSearchAdd.svelte
@@ -2,6 +2,7 @@
 	import { fluxogramaStore } from '$lib/stores/fluxograma.store.svelte';
 	import { gradeStore } from '$lib/stores/grade.store.svelte';
 	import { Search, Plus } from 'lucide-svelte';
+	import HelpTip from '$lib/components/onboarding/HelpTip.svelte';
 
 	// Adiciona uma matéria da matriz do curso ao pool. A página resolve turmas.
 	let { onAdd }: { onAdd: (codigo: string) => void } = $props();
@@ -27,7 +28,14 @@
 	}
 </script>
 
-<div class="rounded-2xl border border-white/10 bg-zinc-950/78 p-3">
+<div class="rounded-2xl border border-white/10 bg-zinc-950/78 p-3" data-tour="buscar-materia">
+	<div class="mb-2 flex items-center justify-between gap-2">
+		<p class="text-[11px] font-semibold uppercase tracking-[0.12em] text-white/55">1 · Matérias</p>
+		<HelpTip
+			title="Como achar a matéria"
+			text="Digite o código (ex.: CIC0004) ou parte do nome. Só aparecem matérias da sua matriz que ainda não estão na lista. Precisa de algo fora da matriz? Use “Buscar turmas” no topo."
+		/>
+	</div>
 	<div class="relative">
 		<Search class="pointer-events-none absolute left-3 top-1/2 h-3.5 w-3.5 -translate-y-1/2 text-white/40" />
 		<input

--- a/no_fluxo_frontend_svelte/src/lib/components/planejamento/ScheduleGrid.svelte
+++ b/no_fluxo_frontend_svelte/src/lib/components/planejamento/ScheduleGrid.svelte
@@ -3,6 +3,7 @@
 	import { gradeStore } from '$lib/stores/grade.store.svelte';
 	import { DIAS_SEMANA, SLOTS_DIA, bitIndex, agruparBlocosDia } from '$lib/utils/horario-slots';
 	import { CalendarClock, ChevronsUpDown, LayoutGrid, List } from 'lucide-svelte';
+	import HelpTip from '$lib/components/onboarding/HelpTip.svelte';
 
 	// Clicar num bloco abre a troca de turma daquela matéria (na página).
 	let { onBlocoClick }: { onBlocoClick: (codigo: string) => void } = $props();
@@ -169,7 +170,11 @@
 	}
 </script>
 
-<div class="rounded-2xl border border-white/10 bg-zinc-950/78 p-3 sm:p-4" id="grade-export">
+<div
+	class="rounded-2xl border border-white/10 bg-zinc-950/78 p-3 sm:p-4"
+	id="grade-export"
+	data-tour="calendario"
+>
 	{#if modo === 'grade'}
 		<div class="grade-scroll overflow-x-auto" bind:this={scroller}>
 			<div
@@ -349,7 +354,12 @@
 					</button>
 				{/each}
 			</div>
-			<div class="flex flex-wrap items-center gap-1.5">
+			<div class="flex flex-wrap items-center gap-1.5" data-tour="visualizacao">
+				<HelpTip
+					side="top"
+					title="Formas de ver a grade"
+					text="“Agenda” lista as aulas por dia — melhor no celular. “Semana inteira” mostra também os dias e turnos vazios, útil pra achar buracos livres. Clique num bloco colorido pra trocar de turma."
+				/>
 				<button
 					type="button"
 					onclick={trocarModo}
@@ -379,7 +389,7 @@
 	{:else}
 		<p class="mt-3 flex items-center justify-center gap-2 py-6 text-center text-xs text-white/40">
 			<CalendarClock class="h-4 w-4" />
-			Escolha turmas nas matérias (ou clique em "Montar automático") para ver sua grade.
+			Escolha turmas nas matérias (ou clique em "Rearranjar", no topo) para ver sua grade.
 		</p>
 	{/if}
 </div>

--- a/no_fluxo_frontend_svelte/src/lib/components/planejamento/SubjectTurmaSelector.svelte
+++ b/no_fluxo_frontend_svelte/src/lib/components/planejamento/SubjectTurmaSelector.svelte
@@ -35,7 +35,7 @@
 	}
 </script>
 
-<div class="space-y-3">
+<div class="space-y-3" data-tour="escolher-turma">
 	{#each gradeStore.pool as materia (materia.codigo)}
 		{@const cor = gradeStore.corDaMateria(materia.codigo)}
 		{@const selecionada = gradeStore.turmaSelecionada(materia.codigo)}

--- a/no_fluxo_frontend_svelte/src/lib/stores/grade.store.svelte.ts
+++ b/no_fluxo_frontend_svelte/src/lib/stores/grade.store.svelte.ts
@@ -142,7 +142,7 @@ function createGradeStore() {
 	let ultimaMontagem = $state<MontagemResultado | null>(null);
 	/** Matéria sob o mouse (lista/resumo) — o calendário destaca os blocos dela. */
 	let hoverCodigo = $state<string | null>(null);
-	/** Códigos priorizados: o "Montar automático" tenta encaixá-los primeiro. */
+	/** Códigos priorizados: o "Rearranjar" (montarAutomatico) tenta encaixá-los primeiro. */
 	let prioritarias = $state<Set<string>>(new Set());
 	/** Preferência de turno/professor por matéria (código → preferência). */
 	let preferencias = $state<Record<string, PreferenciaMateria>>({});

--- a/no_fluxo_frontend_svelte/src/routes/(protected)/planejamento/grade/+page.svelte
+++ b/no_fluxo_frontend_svelte/src/routes/(protected)/planejamento/grade/+page.svelte
@@ -29,7 +29,22 @@
 	import { setHasCodeIgnoreCase, filtrarNaoCursados } from '$lib/utils/subject-codes';
 	import { ROUTES } from '$lib/config/routes';
 	import type { SemestrePlano, ItemSemestre, MateriaPlano } from '$lib/types/plano-formatura';
-	import { CalendarDays, Wand2, Trash2, Loader2, Info, Download, Star, Search } from 'lucide-svelte';
+	import {
+		CalendarDays,
+		Wand2,
+		Trash2,
+		Loader2,
+		Info,
+		Download,
+		Star,
+		Search,
+		Compass,
+		Maximize2,
+		Minimize2
+	} from 'lucide-svelte';
+	import OnboardingTour from '$lib/components/onboarding/OnboardingTour.svelte';
+	import HelpTip from '$lib/components/onboarding/HelpTip.svelte';
+	import { tourStore, type TourStep } from '$lib/components/onboarding/tour.store.svelte';
 
 	// Feature em rollout gradual: só admins veem o Montador de Grade de verdade
 	// por enquanto; usuários normais veem um aviso de "em breve" e nem chegam a
@@ -212,6 +227,9 @@
 	);
 	const creditosAcima = $derived(gradeStore.creditosSelecionados > limiteCreditos);
 
+	// Calendário em tela cheia (só faz diferença no desktop; no mobile já é 1 coluna).
+	let calendarioExpandido = $state(false);
+
 	let exportando = $state(false);
 	async function exportarGrade(): Promise<void> {
 		if (exportando) return;
@@ -276,6 +294,87 @@
 		gradeStore.montarAutomatico();
 	}
 
+	// ---------------------------------------------------------------------------
+	// Onboarding guiado
+	// ---------------------------------------------------------------------------
+	const TOUR_ID = 'montador-grade-v1';
+
+	// 7 passos: só o caminho crítico (achar → turma → calendário → rearranjar →
+	// exportar → IA). Turnos, créditos e modos de visualização são secundários e
+	// já têm HelpTip permanente ao lado do próprio controle.
+	const TOUR_STEPS: TourStep[] = [
+		{
+			title: 'Bem-vindo ao Montador de Grade 👋',
+			description:
+				'Em 1 minuto você monta a grade do próximo semestre sem conflito de horário. Já deixamos as matérias recomendadas pelo seu plano na lista — é só escolher as turmas.',
+			hint: 'Dá pra navegar com as setas ← → do teclado e sair com Esc.'
+		},
+		{
+			target: 'buscar-materia',
+			side: 'right',
+			title: '1. Ache a matéria',
+			description:
+				'Digite o código (ex.: CIC0004) ou parte do nome e clique no resultado para jogar a matéria na sua lista. Só aparecem matérias da sua matriz que você ainda não cursou.',
+			hint: 'Quer algo fora da matriz? Use “Buscar turmas”, no topo da página.'
+		},
+		{
+			target: 'escolher-turma',
+			side: 'right',
+			title: '2. Escolha a turma',
+			description:
+				'Cada matéria mostra as turmas ofertadas com professor, horário e vagas. Clique numa turma para colocá-la na grade — clicar de novo tira. A estrela marca a matéria como prioritária.',
+			hint: 'Turma lotada? Dá pra seguir a turma e ser avisado quando abrir vaga.'
+		},
+		{
+			target: 'calendario',
+			side: 'left',
+			title: '3. Veja sua semana',
+			description:
+				'As turmas escolhidas viram blocos coloridos aqui. Conflito de horário aparece destacado na hora, então não tem como se matricular em duas aulas no mesmo slot sem perceber.',
+			hint: 'Clique num bloco para trocar a turma; os controles abaixo do calendário mudam a visualização.'
+		},
+		{
+			target: 'rearranjar',
+			side: 'bottom',
+			title: 'Deixe o automático resolver',
+			description:
+				'“Rearranjar” testa as combinações e encaixa o máximo de matérias sem conflito, respeitando os turnos que você deixar ligados ali ao lado e priorizando as marcadas com estrela. Se algo não couber, a gente avisa.'
+		},
+		{
+			target: 'resumo',
+			side: 'left',
+			title: '4. Confira e exporte',
+			description:
+				'O resumo lista tudo que está na grade com turma e horário. Quando estiver do jeito que você quer, use “Exportar” para baixar a grade em imagem e levar pro dia da matrícula.',
+			hint: 'O contador de créditos no topo compara sua seleção com o limite do seu plano.'
+		},
+		{
+			target: 'assistente-ia',
+			side: 'left',
+			padding: 12,
+			title: '✨ E tem a Darcy, nossa IA',
+			description:
+				'Peça em português: “optativas de redes à tarde com turma aberta” ou “monta minha grade sem aula de manhã”. Ela sugere só matérias com turma neste semestre e joga direto na sua grade.',
+			hint: 'Reveja este passo a passo em “Como funciona”, no topo — e os “?” explicam cada controle.'
+		}
+	];
+
+	function abrirTour(): void {
+		tourStore.start(TOUR_ID, TOUR_STEPS);
+	}
+
+	// Primeira visita: abre sozinho, mas só depois que a grade carregou (senão os
+	// alvos do spotlight ainda nem existem na tela).
+	// Propositalmente NÃO é $state: escrever numa flag reativa aqui invalidaria o
+	// próprio efeito, cujo cleanup cancelaria o timer antes de ele disparar.
+	let tourAutoDisparado = false;
+	$effect(() => {
+		if (status !== 'ready' || tourAutoDisparado) return;
+		tourAutoDisparado = true;
+		const t = setTimeout(() => tourStore.startSeNovo(TOUR_ID, TOUR_STEPS), 500);
+		return () => clearTimeout(t);
+	});
+
 	const TURNO_OPCOES: ReadonlyArray<[Turno, string]> = [
 		['M', 'Manhã'],
 		['T', 'Tarde'],
@@ -320,22 +419,29 @@
 
 		{#if status === 'ready'}
 			<div class="flex w-full flex-wrap items-center gap-2 sm:w-auto">
-				<div
-					class="flex items-center gap-2 rounded-full border border-white/10 bg-white/5 px-3 py-1"
-					title="Créditos selecionados vs. seu limite por semestre"
+				<HelpTip
+					side="bottom"
+					title="Créditos do semestre"
+					text="Soma dos créditos das turmas já escolhidas contra o limite do seu plano. A barra fica amarela perto do limite e vermelha se passar."
 				>
-					<span class="text-xs {creditosAcima ? 'font-semibold text-red-300' : 'text-white/70'}">
-						{gradeStore.creditosSelecionados}/{limiteCreditos} cr
-					</span>
-					<span class="h-1.5 w-16 overflow-hidden rounded-full bg-white/10">
-						<span
-							class="block h-full rounded-full transition-all {creditosAcima ? 'bg-red-400' : creditosPct > 85 ? 'bg-amber-400' : 'bg-emerald-400'}"
-							style="width: {creditosPct}%"
-						></span>
-					</span>
-				</div>
+					<div
+						class="flex items-center gap-2 rounded-full border border-white/10 bg-white/5 px-3 py-1"
+						data-tour="creditos"
+					>
+						<span class="text-xs {creditosAcima ? 'font-semibold text-red-300' : 'text-white/70'}">
+							{gradeStore.creditosSelecionados}/{limiteCreditos} cr
+						</span>
+						<span class="h-1.5 w-16 overflow-hidden rounded-full bg-white/10">
+							<span
+								class="block h-full rounded-full transition-all {creditosAcima ? 'bg-red-400' : creditosPct > 85 ? 'bg-amber-400' : 'bg-emerald-400'}"
+								style="width: {creditosPct}%"
+							></span>
+						</span>
+					</div>
+				</HelpTip>
 				<div
 					class="flex items-center gap-0.5 rounded-full border border-white/10 bg-white/5 p-0.5"
+					data-tour="turnos"
 					title="Turnos permitidos ao rearranjar"
 				>
 					{#each TURNO_OPCOES as [t, label] (t)}
@@ -352,32 +458,50 @@
 						</button>
 					{/each}
 				</div>
-				<button
-					type="button"
-					onclick={() => gradeStore.montarAutomatico()}
-					title={gradeStore.temPrioritarias
-						? 'Rearranja sem conflito priorizando as matérias com estrela'
-						: 'Monta uma grade sem conflito. Marque matérias com estrela para priorizá-las.'}
-					class="inline-flex touch-manipulation items-center gap-1.5 rounded-full border border-purple-300/45 bg-purple-500/18 px-3 py-2 text-xs font-semibold text-purple-100 transition-colors hover:bg-purple-500/25 sm:py-1.5"
+				<HelpTip
+					side="bottom"
+					title="Rearranjar (montagem automática)"
+					text={gradeStore.temPrioritarias
+						? 'Rearranja tudo sem conflito de horário, começando pelas matérias com estrela.'
+						: 'Encaixa suas matérias sem conflito de horário, respeitando os turnos escolhidos. Marque estrela numa matéria para ela entrar primeiro.'}
 				>
-					<Wand2 class="h-3.5 w-3.5" /> Rearranjar
-					{#if gradeStore.temPrioritarias}<Star class="h-3 w-3 fill-current text-amber-300" />{/if}
-				</button>
-				<button
-					type="button"
-					onclick={exportarGrade}
-					disabled={exportando || gradeStore.selecao.size === 0}
-					class="inline-flex touch-manipulation items-center gap-1.5 rounded-full border border-white/15 bg-white/5 px-3 py-2 text-xs font-medium text-white/70 transition-colors hover:bg-white/10 sm:py-1.5 disabled:opacity-40"
+					<button
+						type="button"
+						onclick={() => gradeStore.montarAutomatico()}
+						data-tour="rearranjar"
+						class="inline-flex touch-manipulation items-center gap-1.5 rounded-full border border-purple-300/45 bg-purple-500/18 px-3 py-2 text-xs font-semibold text-purple-100 transition-colors hover:bg-purple-500/25 sm:py-1.5"
+					>
+						<Wand2 class="h-3.5 w-3.5" /> Rearranjar
+						{#if gradeStore.temPrioritarias}<Star class="h-3 w-3 fill-current text-amber-300" />{/if}
+					</button>
+				</HelpTip>
+				<HelpTip
+					side="bottom"
+					title="Exportar"
+					text="Baixa a grade como imagem PNG — boa pra mandar no grupo do curso ou conferir na hora da matrícula."
 				>
-					{#if exportando}<Loader2 class="h-3.5 w-3.5 animate-spin" />{:else}<Download class="h-3.5 w-3.5" />{/if} Exportar
-				</button>
-				<a
-					href={ROUTES.BUSCAR_TURMAS}
-					title="Procurar na oferta inteira por professor, horário ou sala"
-					class="inline-flex touch-manipulation items-center gap-1.5 rounded-full border border-white/15 bg-white/5 px-3 py-2 text-xs font-medium text-white/70 transition-colors hover:bg-white/10 sm:py-1.5"
+					<button
+						type="button"
+						onclick={exportarGrade}
+						disabled={exportando || gradeStore.selecao.size === 0}
+						data-tour="exportar"
+						class="inline-flex touch-manipulation items-center gap-1.5 rounded-full border border-white/15 bg-white/5 px-3 py-2 text-xs font-medium text-white/70 transition-colors hover:bg-white/10 sm:py-1.5 disabled:opacity-40"
+					>
+						{#if exportando}<Loader2 class="h-3.5 w-3.5 animate-spin" />{:else}<Download class="h-3.5 w-3.5" />{/if} Exportar
+					</button>
+				</HelpTip>
+				<HelpTip
+					side="bottom"
+					title="Buscar turmas"
+					text="Procura na oferta inteira do semestre por professor, horário ou sala — inclusive matérias que não estão na sua matriz."
 				>
-					<Search class="h-3.5 w-3.5" /> Buscar turmas
-				</a>
+					<a
+						href={ROUTES.BUSCAR_TURMAS}
+						class="inline-flex touch-manipulation items-center gap-1.5 rounded-full border border-white/15 bg-white/5 px-3 py-2 text-xs font-medium text-white/70 transition-colors hover:bg-white/10 sm:py-1.5"
+					>
+						<Search class="h-3.5 w-3.5" /> Buscar turmas
+					</a>
+				</HelpTip>
 				<button
 					type="button"
 					onclick={() => gradeStore.limpar()}
@@ -385,6 +509,19 @@
 				>
 					<Trash2 class="h-3.5 w-3.5" /> Limpar
 				</button>
+				<HelpTip
+					side="bottom"
+					title="Tour guiado"
+					text="Refaz o passo a passo do montador quando quiser."
+				>
+					<button
+						type="button"
+						onclick={abrirTour}
+						class="inline-flex touch-manipulation items-center gap-1.5 rounded-full border border-purple-300/30 bg-purple-500/10 px-3 py-2 text-xs font-medium text-purple-100/90 transition-colors hover:bg-purple-500/20 sm:py-1.5"
+					>
+						<Compass class="h-3.5 w-3.5" /> Como funciona
+					</button>
+				</HelpTip>
 			</div>
 		{/if}
 	</header>
@@ -420,36 +557,102 @@
 	{:else if status === 'error'}
 		<div class="rounded-2xl border border-red-300/30 bg-red-500/10 px-4 py-6 text-center text-sm text-red-200">{erro}</div>
 	{:else}
-		<div class="grid gap-4 lg:grid-cols-[22rem_minmax(0,1fr)_18rem]">
-			<!-- Coluna esquerda: matérias + busca -->
-			<div class="order-2 space-y-3 lg:order-1 lg:sticky lg:top-24 lg:max-h-[calc(100dvh-9rem)] lg:overflow-y-auto lg:pr-0.5">
-				<MateriaSearchAdd onAdd={adicionarAoPool} />
-				{#if avisoAdd}
-					<p class="rounded-lg border border-amber-300/30 bg-amber-500/10 px-3 py-2 text-[11px] text-amber-100">{avisoAdd}</p>
-				{/if}
-				{#if gradeStore.pool.length === 0}
-					<p class="rounded-2xl border border-white/10 bg-zinc-950/78 px-3 py-6 text-center text-xs text-white/50">
+		<!--
+			As três áreas viram snippets para poderem ser rearranjadas sem duplicação:
+			no modo normal o calendário fica ao centro com matérias à esquerda e resumo
+			à direita (ordem 1→2→3→4 do tour); no modo ampliado ele ocupa a largura
+			toda e os painéis descem para uma linha abaixo.
+		-->
+		{#snippet colunaMaterias()}
+			<MateriaSearchAdd onAdd={adicionarAoPool} />
+			{#if avisoAdd}
+				<p class="rounded-lg border border-amber-300/30 bg-amber-500/10 px-3 py-2 text-[11px] text-amber-100">{avisoAdd}</p>
+			{/if}
+			{#if gradeStore.pool.length === 0}
+				<div class="rounded-2xl border border-white/10 bg-zinc-950/78 px-3 py-6 text-center">
+					<p class="text-xs text-white/50">
 						Busque matérias acima ou peça recomendações ao assistente (botão flutuante).
 					</p>
-				{:else}
-					<SubjectTurmaSelector />
-				{/if}
-			</div>
+					<button
+						type="button"
+						onclick={abrirTour}
+						class="mt-3 inline-flex items-center gap-1.5 rounded-full border border-purple-300/35 bg-purple-500/12 px-3 py-1.5 text-[11px] font-medium text-purple-100 transition-colors hover:bg-purple-500/22"
+					>
+						<Compass class="h-3.5 w-3.5" /> Ver o passo a passo
+					</button>
+				</div>
+			{:else}
+				<div class="flex items-center justify-between gap-2 px-1 pt-1">
+					<p class="text-[11px] font-semibold uppercase tracking-[0.12em] text-white/55">2 · Turmas</p>
+					<HelpTip
+						title="Escolha uma turma por matéria"
+						text="Clique numa turma para colocá-la na grade; clicar de novo tira. A estrela marca a matéria como prioritária no Rearranjar."
+					/>
+				</div>
+				<SubjectTurmaSelector />
+			{/if}
+		{/snippet}
 
-			<!-- Centro: calendário -->
-			<div class="order-1 lg:order-2">
-				<ScheduleGrid onBlocoClick={(codigo) => (materiaDialog = codigo)} />
+		{#snippet calendario()}
+			<div class="mb-1.5 flex items-center justify-between px-1">
+				<p class="text-[11px] font-semibold uppercase tracking-[0.12em] text-white/55">
+					3 · Sua semana
+				</p>
+				<HelpTip
+					side="left"
+					title={calendarioExpandido ? 'Voltar ao layout compacto' : 'Ampliar o calendário'}
+					text={calendarioExpandido
+						? 'Traz matérias e resumo de volta para o lado do calendário.'
+						: 'O calendário ocupa a tela inteira e os painéis descem — melhor pra enxergar a semana toda.'}
+				>
+					<button
+						type="button"
+						onclick={() => (calendarioExpandido = !calendarioExpandido)}
+						data-tour="ampliar"
+						class="hidden touch-manipulation items-center gap-1 rounded-full border border-white/10 bg-white/5 px-2 py-1 text-[10px] text-white/55 transition-colors hover:bg-white/10 lg:inline-flex"
+					>
+						{#if calendarioExpandido}
+							<Minimize2 class="h-3 w-3" /> Reduzir
+						{:else}
+							<Maximize2 class="h-3 w-3" /> Ampliar
+						{/if}
+					</button>
+				</HelpTip>
 			</div>
+			<ScheduleGrid onBlocoClick={(codigo) => (materiaDialog = codigo)} />
+		{/snippet}
 
-			<!-- Direita: resumo -->
-			<div class="order-3">
-				<GradeResumo />
+		{#if calendarioExpandido}
+			<div class="space-y-4">
+				<div>{@render calendario()}</div>
+				<div class="grid gap-4 lg:grid-cols-[minmax(0,1fr)_20rem]">
+					<div class="space-y-3">{@render colunaMaterias()}</div>
+					<div><GradeResumo /></div>
+				</div>
 			</div>
-		</div>
+		{:else}
+			<div class="grid gap-4 lg:grid-cols-[22rem_minmax(0,1fr)_18rem]">
+				<!-- Coluna esquerda: matérias + busca -->
+				<div class="order-2 space-y-3 lg:order-1 lg:sticky lg:top-24 lg:max-h-[calc(100dvh-9rem)] lg:overflow-y-auto lg:pr-0.5">
+					{@render colunaMaterias()}
+				</div>
+
+				<!-- Centro: calendário -->
+				<div class="order-1 lg:order-2">{@render calendario()}</div>
+
+				<!-- Direita: resumo -->
+				<div class="order-3">
+					<GradeResumo />
+				</div>
+			</div>
+		{/if}
 	{/if}
 </div>
 
 <TrocarTurmaDialog codigo={materiaDialog} onClose={() => (materiaDialog = null)} />
+
+<!-- Onboarding guiado (spotlight + coach marks) -->
+<OnboardingTour />
 
 <!-- Chatbot flutuante (Darcy) — recomenda optativas com turma e insere na grade -->
 {#if status === 'ready'}


### PR DESCRIPTION
…ário ampliável

Primeiro acesso ao Montador de Grade não explicava nada e o layout fixo de 3 colunas espremia o calendário. Adiciona um tour de 7 passos que percorre o fluxo real — achar matéria, escolher turma, ler o calendário, montar automático, conferir/exportar e a Darcy — e reorganiza a tela na mesma ordem do tour, com o calendário alternando entre compacto e tela cheia.

- onboarding/tour.store.svelte.ts: estado dos passos + "já viu" em localStorage; dispensa acidental (clique fora/X/Esc) não persiste — só "Entendi!" e "Pular" gravam, e Pular aponta o "Como funciona" via toast; storage bloqueado (aba anônima) conta como "não visto"
- onboarding/OnboardingTour.svelte: coach marks com spotlight recortado, card auto-posicionado, navegação por teclado/dots e reduced-motion; só transição de entrada — o outro não completava e deixava véu invisível bloqueando a página
- onboarding/HelpTip.svelte: tooltip de ajuda no DS sobre o shadcn/bits-ui, usando o snippet `child` para não aninhar botões no gatilho
- grade/+page: áreas viram snippets; botão Ampliar/Reduzir põe a semana em largura total com matérias+resumo abaixo; seções numeradas 1·Matérias, 2·Turmas, 3·Sua semana, 4·Resumo espelhando os passos do tour
- âncoras data-tour na busca, seletor, calendário, resumo e FAB da IA; botão "Como funciona" no cabeçalho reabre o tour a qualquer momento
- textos atualizados: "Montar automático" → "Rearranjar" (botão real)

## 📌 Descrição

Descreva brevemente o que foi feito nesta PR.

## 🔗 Issue Relacionada

Closes #

## ✅ Tipo de Mudança

- [ ] Correção de bug
- [ ] Nova funcionalidade
- [ ] Refatoração
- [ ] Documentação

## 🔍 Checklist

- [ ] Testes criados/atualizados
- [ ] Documentação atualizada (se necessário)
- [ ] PR revisada e pronta para merge
