### PR TITLE
  fix(modal): corrige modal de novidades prendendo o usuário no mobile

### DIFF
--- a/no_fluxo_frontend_svelte/src/lib/components/fluxograma/modal/MateriasConcluidasModal.svelte
+++ b/no_fluxo_frontend_svelte/src/lib/components/fluxograma/modal/MateriasConcluidasModal.svelte
@@ -208,7 +208,7 @@
 	role="presentation"
 	onclick={(e) => e.target === e.currentTarget && onclose()}
 >
-	<div class="flex max-h-[90vh] w-full max-w-2xl flex-col overflow-hidden rounded-xl border border-white/10 bg-gray-900/95 shadow-2xl backdrop-blur-xl">
+	<div class="flex max-h-[90dvh] w-full max-w-2xl flex-col overflow-hidden rounded-xl border border-white/10 bg-gray-900/95 shadow-2xl backdrop-blur-xl">
 		<div class="flex items-center justify-between border-b border-fuchsia-400/30 bg-gradient-to-r from-fuchsia-600/25 via-purple-600/20 to-cyan-600/20 px-4 py-3 sm:px-6">
 			<div>
 				<h2 class="text-base font-bold text-white sm:text-lg">Materias concluidas do usuario</h2>

--- a/no_fluxo_frontend_svelte/src/lib/components/fluxograma/modal/SubjectDetailsModal.svelte
+++ b/no_fluxo_frontend_svelte/src/lib/components/fluxograma/modal/SubjectDetailsModal.svelte
@@ -89,7 +89,7 @@ import { ROUTES } from '$lib/config/routes';
 	onclick={handleBackdropClick}
 >
 	<div
-		class="relative max-h-[90vh] w-full max-w-lg overflow-hidden rounded-xl border border-white/10 bg-gray-900/95 shadow-2xl backdrop-blur-xl sm:max-h-[85vh] sm:rounded-2xl"
+		class="relative max-h-[90dvh] w-full max-w-lg overflow-hidden rounded-xl border border-white/10 bg-gray-900/95 shadow-2xl backdrop-blur-xl sm:max-h-[85dvh] sm:rounded-2xl"
 		role="dialog"
 		aria-modal="true"
 		aria-label="Detalhes da matéria"

--- a/no_fluxo_frontend_svelte/src/lib/components/fluxograma/modal/SubjectDetailsModal.svelte
+++ b/no_fluxo_frontend_svelte/src/lib/components/fluxograma/modal/SubjectDetailsModal.svelte
@@ -9,6 +9,7 @@
 		import { portal } from '$lib/actions/portal';
 import { ROUTES } from '$lib/config/routes';
 	import { formatLocalSigaa, formatVagas, horarioLegivel } from '$lib/utils/sigaa';
+	import { getLogicalCodeGroups } from '$lib/utils/expressao-logica';
 	import ManualStatusEditor from './ManualStatusEditor.svelte';
 	import SubjectClassesTab from './SubjectClassesTab.svelte';
 

--- a/no_fluxo_frontend_svelte/src/lib/components/layout/ReleaseNotesModal.svelte
+++ b/no_fluxo_frontend_svelte/src/lib/components/layout/ReleaseNotesModal.svelte
@@ -108,8 +108,15 @@
 			onkeydown={(e) => e.key === 'Enter' && marcarVisto()}
 		></div>
 
+		<!--
+			Altura em dvh (não vh): no mobile, 100vh é a altura SEM a barra do
+			navegador, então o card estourava a área visível e o rodapé com
+			"Entendi" ficava fora da tela — sem scroll no overlay e sem backdrop
+			sobrando para tocar, o usuário ficava preso. Mesmo padrão do
+			TrocarTurmaDialog.
+		-->
 		<div
-			class="relative z-10 flex max-h-[88vh] w-full max-w-md flex-col overflow-hidden rounded-2xl border border-white/10 bg-[#0e1117] shadow-2xl"
+			class="relative z-10 flex max-h-[88dvh] w-full max-w-md flex-col overflow-hidden rounded-2xl border border-white/10 bg-[#0e1117] shadow-2xl"
 			transition:fly={{ y: 24, duration: 250 }}
 		>
 			<!-- Header -->
@@ -135,8 +142,8 @@
 				</button>
 			</div>
 
-			<!-- Novidades -->
-			<div class="min-h-0 overflow-y-auto px-6 py-6">
+			<!-- Novidades (overscroll-contain: rolar aqui não arrasta a página) -->
+			<div class="min-h-0 overflow-y-auto overscroll-contain px-6 py-6">
 				<ul class="flex flex-col gap-3">
 					{#each RELEASE_NOVIDADES as novidade}
 						<li class="flex items-start gap-2.5">
@@ -191,8 +198,11 @@
 				{/if}
 			</div>
 
-			<!-- Ações -->
-			<div class="flex items-center justify-between gap-3 border-t border-white/8 px-6 py-4">
+			<!-- Ações (shrink-0 + safe area: o rodapé nunca some nem fica sob a
+			     barra de gestos do iPhone) -->
+			<div
+				class="flex shrink-0 items-center justify-between gap-3 border-t border-white/8 px-6 pt-4 pb-[max(1rem,env(safe-area-inset-bottom))]"
+			>
 				<button
 					type="button"
 					onclick={marcarVisto}


### PR DESCRIPTION
## 📌 Descrição

  Corrige o modal de novidades que, no mobile, deixava o usuário preso: o rodapé
  com o botão **"Entendi" ficava fora da tela** e não havia como rolar até ele nem
  fechar o modal — travando o uso do site.

  **Causa:** o card usava `max-h-[88vh]`. Em navegador mobile, `100vh` é a altura da
  viewport **sem** a barra de endereço, ou seja, maior que a área realmente visível.
  Com o conteúdo deste release (5 novidades + aviso de reenvio de histórico + nota da
  equipe), o card estourava a tela. Como o overlay é `fixed` e sem scroll, e o card
  cobria todo o backdrop, não sobrava nem o toque-fora para dispensar.

  **Correção:** troca para `dvh` (altura dinâmica = área visível de verdade), padrão
  que o projeto **já usa** no `TrocarTurmaDialog` e no `PrerequisiteChainDialog`.
  Somado a isso:
  - `overscroll-contain` na lista de novidades, para a rolagem não arrastar a página;
  - rodapé com `shrink-0` + `env(safe-area-inset-bottom)`, para os botões não
    encolherem nem ficarem sob a barra de gestos do iPhone.

  A mesma troca `vh → dvh` foi aplicada no `SubjectDetailsModal` e no
  `MateriasConcluidasModal`, que tinham o defeito idêntico (menos grave, porque o
  botão de fechar fica no cabeçalho).

  ### Bônus: bug encontrado pelo `svelte-check` durante a validação

  O `SubjectDetailsModal` chamava `getLogicalCodeGroups(...)` **sem importar a
  função** — `ReferenceError` ao abrir os detalhes de uma matéria cujo pré-requisito
  usa `expressao_original`, que é o formato que o banco usa hoje. A função já existia
  e era testada em `$lib/utils/expressao-logica`; faltava só a linha de import.
  Vai em commit separado, para poder ser revertido de forma independente.

  ## 🔗 Issue Relacionada

  Closes #

  Relacionada a #150 — o `ReferenceError` acima é um forte candidato à causa do
  (eventos do canvas). Vale validar antes de fechá-la por esta PR. 

  ## ✅ Tipo de Mudança
  
  - [x] Correção de bug
  - [ ] Nova funcionalidade
  - [ ] Refatoração
  - [ ] Documentação

  ## 🔍 Checklist
  
  - [ ] Testes criados/atualizados
  - [x] Documentação atualizada (se necessário) — não aplicável
  - [ ] PR revisada e pronta para merge

  ## 🧪 Como testar
  
  No **celular**, logado:
  1. No console: `localStorage.removeItem('nofluxo:release-vista:SEU_ID_USER')`
  2. Recarregue a página.
  3. O botão **"Entendi"** deve estar visível sem precisar rolar, e o modal deve
     fechar tanto por ele quanto tocando fora.
  4. No fluxograma, abra uma matéria que tenha pré-requisito com expressão
     (ex.: "A ou B") e confira a aba **Pré-requisitos** — antes quebrava.

  ## 📋 Notas para revisão
  
  - **Sem testes automatizados nesta PR.** O fix principal é de viewport/CSS e o
    segundo é um import ausente. Dá para cobrir o primeiro com Playwright em viewport
    mobile (o projeto já tem `playwright.config.ts`) — digam se querem que eu
    adicione antes do merge. 
  - Verificado: `npm run build` passa e `npm run check` foi de **4 para 3 erros**
    (o de `getLogicalCodeGroups` sumiu). Os 3 restantes são **pré-existentes** e em
    outros arquivos: `ManualStatusEditor`, `SemestrePlanCard` e
    `upload-historico/+page`.
  - `dvh` tem suporte em iOS Safari 15.4+ e Chrome 108+, e já é usado em produção
    neste repo.