### PR TITLE
refactor/feat: agrupar fluxogramas por turno em vez de listar todas as matrizes

### DIFF
--- a/no_fluxo_backend/package.json
+++ b/no_fluxo_backend/package.json
@@ -47,6 +47,7 @@
     "zod": "^4.4.3"
   },
   "devDependencies": {
+    "@types/body-parser": "^1.19.6",
     "@types/cors": "^2.8.17",
     "@types/express": "^4.17.21",
     "@types/form-data": "^2.2.1",

--- a/no_fluxo_frontend_svelte/src/lib/mocks/cursos.mock.ts
+++ b/no_fluxo_frontend_svelte/src/lib/mocks/cursos.mock.ts
@@ -1,0 +1,50 @@
+export const mockCursos = [
+  {
+    id_curso: 1,
+    nome_curso: 'Engenharia de Software',
+    tipo_curso: 'graduacao',
+    turno: 'DIURNO',
+    criado_em: '2023-01-01T00:00:00.000Z',
+    atualizado_em: '2023-01-01T00:00:00.000Z'
+  },
+  {
+    id_curso: 2,
+    nome_curso: 'Sistemas de Informação',
+    tipo_curso: 'graduacao',
+    turno: 'NOTURNO',
+    criado_em: '2023-01-01T00:00:00.000Z',
+    atualizado_em: '2023-01-01T00:00:00.000Z'
+  },
+  {
+    id_curso: 3,
+    nome_curso: 'Ciência da Computação',
+    tipo_curso: 'graduacao',
+    turno: 'DIURNO',
+    criado_em: '2023-01-01T00:00:00.000Z',
+    atualizado_em: '2023-01-01T00:00:00.000Z'
+  }
+];
+
+export const mockCursosWithCreditos = [
+  {
+    ...mockCursos[0],
+    total_creditos: 240,
+    cred_obrigatorio_exigido: 160,
+    cred_optativo_exigido: 60,
+    cred_complementar_exigido: 20
+  },
+  {
+    ...mockCursos[1],
+    total_creditos: 200,
+    cred_obrigatorio_exigido: 140,
+    cred_optativo_exigido: 40,
+    cred_complementar_exigido: 20
+  },
+  {
+    ...mockCursos[2],
+    total_creditos: 260,
+    cred_obrigatorio_exigido: 180,
+    cred_optativo_exigido: 60,
+    cred_complementar_exigido: 20
+  }
+];

--- a/no_fluxo_frontend_svelte/src/routes/fluxogramas/+page.svelte
+++ b/no_fluxo_frontend_svelte/src/routes/fluxogramas/+page.svelte
@@ -8,6 +8,7 @@
 	import type { MinimalCursoModel } from '$lib/types/curso';
 	import { Search, Filter, ChevronLeft, ChevronRight, Loader2, AlertTriangle, GraduationCap } from 'lucide-svelte';
 	import { onMount } from 'svelte';
+	import Error from '../+error.svelte';
 
 	// Agora cada item representa uma MATRIZ (curso + currículo).
 	let courses = $state<MinimalCursoModel[]>([]);
@@ -88,16 +89,28 @@
 		currentPage = 1;
 	}
 
+	// onMount(async () => {
+	// 	try {
+	// 		// Lista TODAS as matrizes com informações de curso
+	// 		courses = await fluxogramaService.getAllMatrizesIndex();
+	// 	} catch (err) {
+	// 		error = err instanceof Error ? err.message : 'Erro ao carregar cursos';
+	// 	} finally {
+	// 		loading = false;
+	// 	}
+	// });
+
 	onMount(async () => {
-		try {
-			// Lista TODAS as matrizes com informações de curso
-			courses = await fluxogramaService.getAllMatrizesIndex();
+	    try {
+		    // Lista todos os cursos únicos
+		    courses = await fluxogramaService.getAllCursos();
 		} catch (err) {
-			error = err instanceof Error ? err.message : 'Erro ao carregar cursos';
+		    error = err instanceof Error ? err.message : 'Erro ao carregar cursos';
+		    console.error('FluxogramaService.getAllCursos error:', err);
 		} finally {
-			loading = false;
+		    loading = false;
 		}
-	});
+    });
 
 	function navigateToCourse(curso: MinimalCursoModel) {
 		const url = ROUTES.meuFluxograma(curso.nomeCurso);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -55,6 +55,9 @@ importers:
         specifier: ^4.4.3
         version: 4.4.3
     devDependencies:
+      '@types/body-parser':
+        specifier: ^1.19.6
+        version: 1.19.6
       '@types/cors':
         specifier: ^2.8.17
         version: 2.8.19
@@ -2089,6 +2092,7 @@ packages:
 
   '@ungap/structured-clone@1.3.0':
     resolution: {integrity: sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==}
+    deprecated: Potential CWE-502 - Update to 1.3.1 or higher
 
   '@vite-pwa/sveltekit@1.1.0':
     resolution: {integrity: sha512-mMIf2tY+7Hg8jecpu/WY+Ki2ikoXy3hVmt3tOxi0K+lYYnKQrDYthuHireI0S+26Mg9BXzL7qQF1xeB5VYlYlg==}
@@ -2865,6 +2869,7 @@ packages:
   eslint@9.39.3:
     resolution: {integrity: sha512-VmQ+sifHUbI/IcSopBCF/HO3YiHQx/AVd3UVyYL6weuwW+HvON9VYn5l6Zl1WZzPWXPNZrSQpxwkkZ/VuvJZzg==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    deprecated: This version is no longer supported. Please see https://eslint.org/version-support for other options.
     hasBin: true
     peerDependencies:
       jiti: '*'
@@ -6378,7 +6383,7 @@ snapshots:
   '@jest/console@29.7.0':
     dependencies:
       '@jest/types': 29.6.3
-      '@types/node': 20.19.35
+      '@types/node': 25.3.3
       chalk: 4.1.2
       jest-message-util: 29.7.0
       jest-util: 29.7.0
@@ -6391,14 +6396,14 @@ snapshots:
       '@jest/test-result': 29.7.0
       '@jest/transform': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 20.19.35
+      '@types/node': 25.3.3
       ansi-escapes: 4.3.2
       chalk: 4.1.2
       ci-info: 3.9.0
       exit: 0.1.2
       graceful-fs: 4.2.11
       jest-changed-files: 29.7.0
-      jest-config: 29.7.0(@types/node@20.19.35)(ts-node@10.9.2(@types/node@20.19.35)(typescript@5.9.3))
+      jest-config: 29.7.0(@types/node@25.3.3)(ts-node@10.9.2(@types/node@20.19.35)(typescript@5.9.3))
       jest-haste-map: 29.7.0
       jest-message-util: 29.7.0
       jest-regex-util: 29.6.3
@@ -6425,7 +6430,7 @@ snapshots:
     dependencies:
       '@jest/fake-timers': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 20.19.35
+      '@types/node': 25.3.3
       jest-mock: 29.7.0
 
   '@jest/expect-utils@29.7.0':
@@ -6447,7 +6452,7 @@ snapshots:
     dependencies:
       '@jest/types': 29.6.3
       '@sinonjs/fake-timers': 10.3.0
-      '@types/node': 20.19.35
+      '@types/node': 25.3.3
       jest-message-util: 29.7.0
       jest-mock: 29.7.0
       jest-util: 29.7.0
@@ -6476,7 +6481,7 @@ snapshots:
       '@jest/transform': 29.7.0
       '@jest/types': 29.6.3
       '@jridgewell/trace-mapping': 0.3.31
-      '@types/node': 20.19.35
+      '@types/node': 25.3.3
       chalk: 4.1.2
       collect-v8-coverage: 1.0.3
       exit: 0.1.2
@@ -6550,7 +6555,7 @@ snapshots:
       '@jest/schemas': 29.6.3
       '@types/istanbul-lib-coverage': 2.0.6
       '@types/istanbul-reports': 3.0.4
-      '@types/node': 20.19.35
+      '@types/node': 25.3.3
       '@types/yargs': 17.0.35
       chalk: 4.1.2
 
@@ -7104,7 +7109,7 @@ snapshots:
   '@types/body-parser@1.19.6':
     dependencies:
       '@types/connect': 3.4.38
-      '@types/node': 20.19.35
+      '@types/node': 25.3.3
 
   '@types/chai@5.2.3':
     dependencies:
@@ -7113,7 +7118,7 @@ snapshots:
 
   '@types/connect@3.4.38':
     dependencies:
-      '@types/node': 20.19.35
+      '@types/node': 25.3.3
 
   '@types/cookie@0.6.0': {}
 
@@ -7148,7 +7153,7 @@ snapshots:
 
   '@types/express-serve-static-core@4.19.8':
     dependencies:
-      '@types/node': 20.19.35
+      '@types/node': 25.3.3
       '@types/qs': 6.14.0
       '@types/range-parser': 1.2.7
       '@types/send': 1.2.1
@@ -7166,7 +7171,7 @@ snapshots:
 
   '@types/graceful-fs@4.1.9':
     dependencies:
-      '@types/node': 20.19.35
+      '@types/node': 25.3.3
 
   '@types/http-errors@2.0.5': {}
 
@@ -7219,16 +7224,16 @@ snapshots:
   '@types/send@0.17.6':
     dependencies:
       '@types/mime': 1.3.5
-      '@types/node': 20.19.35
+      '@types/node': 25.3.3
 
   '@types/send@1.2.1':
     dependencies:
-      '@types/node': 20.19.35
+      '@types/node': 25.3.3
 
   '@types/serve-static@1.15.10':
     dependencies:
       '@types/http-errors': 2.0.5
-      '@types/node': 20.19.35
+      '@types/node': 25.3.3
       '@types/send': 0.17.6
 
   '@types/stack-utils@2.0.3': {}
@@ -7239,7 +7244,7 @@ snapshots:
 
   '@types/ws@8.18.1':
     dependencies:
-      '@types/node': 20.19.35
+      '@types/node': 25.3.3
 
   '@types/yargs-parser@21.0.3': {}
 
@@ -8952,7 +8957,7 @@ snapshots:
     dependencies:
       es-errors: 1.3.0
       hasown: 2.0.4
-      side-channel: 1.1.0
+      side-channel: 1.1.1
 
   ip-address@10.4.0:
     optional: true
@@ -9165,7 +9170,7 @@ snapshots:
       '@jest/expect': 29.7.0
       '@jest/test-result': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 20.19.35
+      '@types/node': 25.3.3
       chalk: 4.1.2
       co: 4.6.0
       dedent: 1.7.2
@@ -9235,6 +9240,37 @@ snapshots:
       - babel-plugin-macros
       - supports-color
 
+  jest-config@29.7.0(@types/node@25.3.3)(ts-node@10.9.2(@types/node@20.19.35)(typescript@5.9.3)):
+    dependencies:
+      '@babel/core': 7.29.0
+      '@jest/test-sequencer': 29.7.0
+      '@jest/types': 29.6.3
+      babel-jest: 29.7.0(@babel/core@7.29.0)
+      chalk: 4.1.2
+      ci-info: 3.9.0
+      deepmerge: 4.3.1
+      glob: 7.2.3
+      graceful-fs: 4.2.11
+      jest-circus: 29.7.0
+      jest-environment-node: 29.7.0
+      jest-get-type: 29.6.3
+      jest-regex-util: 29.6.3
+      jest-resolve: 29.7.0
+      jest-runner: 29.7.0
+      jest-util: 29.7.0
+      jest-validate: 29.7.0
+      micromatch: 4.0.8
+      parse-json: 5.2.0
+      pretty-format: 29.7.0
+      slash: 3.0.0
+      strip-json-comments: 3.1.1
+    optionalDependencies:
+      '@types/node': 25.3.3
+      ts-node: 10.9.2(@types/node@20.19.35)(typescript@5.9.3)
+    transitivePeerDependencies:
+      - babel-plugin-macros
+      - supports-color
+
   jest-diff@29.7.0:
     dependencies:
       chalk: 4.1.2
@@ -9266,7 +9302,7 @@ snapshots:
       '@jest/environment': 29.7.0
       '@jest/fake-timers': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 20.19.35
+      '@types/node': 25.3.3
       jest-mock: 29.7.0
       jest-util: 29.7.0
 
@@ -9276,7 +9312,7 @@ snapshots:
     dependencies:
       '@jest/types': 29.6.3
       '@types/graceful-fs': 4.1.9
-      '@types/node': 20.19.35
+      '@types/node': 25.3.3
       anymatch: 3.1.3
       fb-watchman: 2.0.2
       graceful-fs: 4.2.11
@@ -9335,7 +9371,7 @@ snapshots:
   jest-mock@29.7.0:
     dependencies:
       '@jest/types': 29.6.3
-      '@types/node': 20.19.35
+      '@types/node': 25.3.3
       jest-util: 29.7.0
 
   jest-mock@30.4.1:
@@ -9378,7 +9414,7 @@ snapshots:
       '@jest/test-result': 29.7.0
       '@jest/transform': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 20.19.35
+      '@types/node': 25.3.3
       chalk: 4.1.2
       emittery: 0.13.1
       graceful-fs: 4.2.11
@@ -9406,7 +9442,7 @@ snapshots:
       '@jest/test-result': 29.7.0
       '@jest/transform': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 20.19.35
+      '@types/node': 25.3.3
       chalk: 4.1.2
       cjs-module-lexer: 1.4.3
       collect-v8-coverage: 1.0.3
@@ -9452,7 +9488,7 @@ snapshots:
   jest-util@29.7.0:
     dependencies:
       '@jest/types': 29.6.3
-      '@types/node': 20.19.35
+      '@types/node': 25.3.3
       chalk: 4.1.2
       ci-info: 3.9.0
       graceful-fs: 4.2.11
@@ -9480,7 +9516,7 @@ snapshots:
     dependencies:
       '@jest/test-result': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 20.19.35
+      '@types/node': 25.3.3
       ansi-escapes: 4.3.2
       chalk: 4.1.2
       emittery: 0.13.1
@@ -9489,7 +9525,7 @@ snapshots:
 
   jest-worker@29.7.0:
     dependencies:
-      '@types/node': 20.19.35
+      '@types/node': 25.3.3
       jest-util: 29.7.0
       merge-stream: 2.0.0
       supports-color: 8.1.1
@@ -10326,7 +10362,6 @@ snapshots:
     dependencies:
       es-errors: 1.3.0
       object-inspect: 1.13.4
-    optional: true
 
   side-channel-map@1.0.1:
     dependencies:
@@ -10358,7 +10393,6 @@ snapshots:
       side-channel-list: 1.0.1
       side-channel-map: 1.0.1
       side-channel-weakmap: 1.0.2
-    optional: true
 
   siginfo@2.0.0: {}
 
@@ -10444,7 +10478,7 @@ snapshots:
       internal-slot: 1.1.0
       regexp.prototype.flags: 1.5.4
       set-function-name: 2.0.2
-      side-channel: 1.1.0
+      side-channel: 1.1.1
 
   string.prototype.trim@1.2.11:
     dependencies:

--- a/supabase/migrations/20260312120000_schema_snapshot_from_export.sql
+++ b/supabase/migrations/20260312120000_schema_snapshot_from_export.sql
@@ -2433,3 +2433,12 @@ CREATE POLICY "users_select_own" ON public."users" AS PERMISSIVE FOR SELECT TO a
 CREATE POLICY "users_update_own" ON public."users" AS PERMISSIVE FOR UPDATE TO authenticated USING ((auth_id = auth.uid())) WITH CHECK ((auth_id = auth.uid()));
 
 COMMIT;
+
+
+-- View creditos_por_curso - lists all courses with their calculated creditos obrigatorios
+CREATE OR REPLACE VIEW public."creditos_por_curso" AS
+SELECT 
+    c."id_curso",
+    public.calcular_creditos_por_curso(c."id_curso") AS creditos_obrigatorios
+FROM public.cursos c
+WHERE c."id_curso" IS NOT NULL;


### PR DESCRIPTION
## 📌 Descrição

**Contexto**

A tela de Fluxogramas listava uma entrada por matriz curricular de cada curso (ex.: 6 cards só para "Administração", um por versão de currículo + turno), totalizando 530 cursos na listagem. Isso poluía a navegação e dificultava encontrar o curso desejado.

**O que mudou**
- A listagem agora agrupa por curso + turno (ex.: "Administração — Diurno", "Administração — Noturno"), reduzindo drasticamente o número de cards exibidos.
- Ao clicar em um turno, a matriz específica pode ser escolhida através de um seletor ("Trocar matriz") na própria tela do fluxograma, mantendo o acesso a todas as versões sem sobrecarregar a tela inicial.

**Como testar**
- Acessar /fluxogramas e confirmar que cada curso aparece no máximo duas vezes (Diurno/Noturno), não uma vez por matriz.
- Clicar em um card e verificar que o fluxograma carrega normalmente.
- No seletor "Trocar matriz", confirmar que todas as matrizes daquele curso+turno aparecem como opção e que trocar recarrega o fluxograma correspondente.

## 🔗 Issue Relacionada

Closes #

## ✅ Tipo de Mudança

- [ ] Correção de bug
- [x] Nova funcionalidade
- [x] Refatoração
- [ ] Documentação

## 🔍 Checklist

- [ ] Testes criados/atualizados
- [ ] Documentação atualizada (se necessário)
- [ ] PR revisada e pronta para merge
